### PR TITLE
CI: activate docker images build

### DIFF
--- a/.github/workflows/publish-jvm-docker-image.yml
+++ b/.github/workflows/publish-jvm-docker-image.yml
@@ -1,13 +1,13 @@
 name: Build and publish JVM-based images
-#on:
-#  push:
-#    branches:
-#      - main
-#    tags:
-#      - 'v*.*.*'
-#  pull_request:
-#    branches:
-#      - main
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build_jvm_docker_image:

--- a/.github/workflows/publish-native-docker-image.yml
+++ b/.github/workflows/publish-native-docker-image.yml
@@ -1,13 +1,13 @@
 name: Build and publish native (GraalVM) images
-#on:
-#  push:
-#    branches:
-#      - main
-#    tags:
-#      - 'v*.*.*'
-#  pull_request:
-#    branches:
-#      - main
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build_native_docker_image:


### PR DESCRIPTION
We are accepted in the OSS program:

<img width="860" height="349" alt="image" src="https://github.com/user-attachments/assets/4481174e-b77f-4c12-b013-62bda5b1546b" />

So we can push the images to Docker Hub now.