### PR TITLE
chore(deps): prevent upgrade to Liquibase v5 because it's not anymore open-source

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,11 @@
   },
   "packageRules": [
     {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["org.liquibase:liquibase-core"],
+      "allowedVersions": "<5.0.0"
+    },
+    {
       "matchPackageNames": ["node"],
       "allowedVersions": "<23.0.0"
     },


### PR DESCRIPTION
See #13419