### PR TITLE
chore(deps): remove obsolete renovate rule for maven-surefire-plugin and maven-failsafe-plugin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,16 +21,6 @@
     {
       "matchPackageNames": ["node"],
       "allowedVersions": "<23.0.0"
-    },
-    {
-      "matchDatasources": ["maven"],
-      "matchPackageNames": [
-        "org.apache.maven.plugins:maven-surefire-plugin",
-        "org.apache.maven.plugins:maven-failsafe-plugin",
-        "surefire-plugin.version",
-        "failsafe-plugin.version"
-      ],
-      "allowedVersions": "<3.5.3 || >3.5.3"
     }
   ]
 }


### PR DESCRIPTION
The issue has been fixed in v3.5.4 of these plugins, and these versions are already used by Seed4J