### PR TITLE
feat(java): support declaring annotation processors to java compiler

### DIFF
--- a/src/main/java/com/seed4j/generator/server/javatool/jacoco/domain/JacocoModuleFactory.java
+++ b/src/main/java/com/seed4j/generator/server/javatool/jacoco/domain/JacocoModuleFactory.java
@@ -58,10 +58,10 @@ public class JacocoModuleFactory {
     return moduleBuilder(properties)
       .mavenPlugins()
         .plugin(mavenJacocoPlugin())
-        .pluginManagement(mavenJacocoWithMinCoverageCheckPluginManagement())
+        .pluginManagement(mavenJacocoWithMinCoverageCheckPluginManagement(properties))
         .and()
       .gradlePlugins()
-        .plugin(gradleJacocoWithMinCoverageCheckPlugin())
+        .plugin(gradleJacocoWithMinCoverageCheckPlugin(properties))
         .and()
       .gradleConfigurations()
         .addTasksTestInstruction(
@@ -82,7 +82,8 @@ public class JacocoModuleFactory {
     return commonMavenJacocoPluginManagement().build();
   }
 
-  private static MavenPlugin mavenJacocoWithMinCoverageCheckPluginManagement() {
+  private static MavenPlugin mavenJacocoWithMinCoverageCheckPluginManagement(Seed4JModuleProperties properties) {
+    String basePackagePath = properties.basePackage().get().replace(".", "/");
     return commonMavenJacocoPluginManagement()
       .addExecution(
         pluginExecution()
@@ -91,6 +92,12 @@ public class JacocoModuleFactory {
           .configuration(
             """
               <dataFile>target/jacoco/allTest.exec</dataFile>
+              <includes>
+                <include>%s/**</include>
+              </includes>
+              <excludes>
+                <exclude>%s/**/infrastructure/secondary/**/*Entity_.class</exclude>
+              </excludes>
               <rules>
                 <rule>
                   <element>CLASS</element>
@@ -108,7 +115,7 @@ public class JacocoModuleFactory {
                   </limits>
                 </rule>
               </rules>
-            """
+            """.formatted(basePackagePath, basePackagePath)
           )
       )
       .build();
@@ -179,7 +186,8 @@ public class JacocoModuleFactory {
       .build();
   }
 
-  private static GradleMainBuildPlugin gradleJacocoWithMinCoverageCheckPlugin() {
+  private static GradleMainBuildPlugin gradleJacocoWithMinCoverageCheckPlugin(Seed4JModuleProperties properties) {
+    String basePackagePath = properties.basePackage().get().replace(".", "/");
     return gradleCorePlugin()
       .id(JACOCO)
       .toolVersionSlug(JACOCO)
@@ -195,11 +203,23 @@ public class JacocoModuleFactory {
             xml.required.set(true)
             html.required.set(true)
           }
+          classDirectories.setFrom(
+            fileTree(layout.buildDirectory.dir("classes")) {
+              include("%s/**")
+              exclude("%s/**/infrastructure/secondary/**/*Entity_*")
+            }
+          )
           executionData.setFrom(fileTree(layout.buildDirectory).include("**/jacoco/test.exec", "**/jacoco/integrationTest.exec"))
         }
 
         tasks.jacocoTestCoverageVerification {
           dependsOn("jacocoTestReport")
+          classDirectories.setFrom(
+            fileTree(layout.buildDirectory.dir("classes")) {
+              include("%s/**")
+              exclude("%s/**/infrastructure/secondary/**/*Entity_*")
+            }
+          )
           violationRules {
 
               rule {
@@ -220,7 +240,7 @@ public class JacocoModuleFactory {
           }
           executionData.setFrom(fileTree(layout.buildDirectory).include("**/jacoco/test.exec", "**/jacoco/integrationTest.exec"))
         }
-        """
+        """.formatted(basePackagePath, basePackagePath, basePackagePath, basePackagePath)
       )
       .build();
   }

--- a/src/main/java/com/seed4j/generator/server/springboot/database/jpa/application/JpaApplicationService.java
+++ b/src/main/java/com/seed4j/generator/server/springboot/database/jpa/application/JpaApplicationService.java
@@ -29,4 +29,8 @@ public class JpaApplicationService {
   public Seed4JModule buildMySQL(Seed4JModuleProperties properties) {
     return jpa.buildMySQL(properties);
   }
+
+  public Seed4JModule buildMetaModelGenerator(Seed4JModuleProperties seed4JModuleProperties) {
+    return jpa.buildMetaModelGenerator(seed4JModuleProperties);
+  }
 }

--- a/src/main/java/com/seed4j/generator/server/springboot/database/jpa/domain/JpaModuleFactory.java
+++ b/src/main/java/com/seed4j/generator/server/springboot/database/jpa/domain/JpaModuleFactory.java
@@ -3,6 +3,7 @@ package com.seed4j.generator.server.springboot.database.jpa.domain;
 import static com.seed4j.module.domain.Seed4JModule.artifactId;
 import static com.seed4j.module.domain.Seed4JModule.from;
 import static com.seed4j.module.domain.Seed4JModule.groupId;
+import static com.seed4j.module.domain.Seed4JModule.javaAnnotationProcessorDependency;
 import static com.seed4j.module.domain.Seed4JModule.moduleBuilder;
 import static com.seed4j.module.domain.Seed4JModule.propertyKey;
 import static com.seed4j.module.domain.Seed4JModule.propertyValue;
@@ -88,6 +89,18 @@ public class JpaModuleFactory {
       .springTestLogger("org.hibernate.validator", LogLevel.WARN)
       .springTestLogger(ORG_HIBERNATE, LogLevel.WARN)
       .springTestLogger("org.hibernate.ejb.HibernatePersistence", LogLevel.OFF);
+    // @formatter:on
+  }
+
+  public Seed4JModule buildMetaModelGenerator(Seed4JModuleProperties properties) {
+    Assert.notNull("properties", properties);
+
+    // @formatter:off
+    return moduleBuilder(properties)
+      .javaCompiler()
+        .addAnnotationProcessor(javaAnnotationProcessorDependency().groupId(ORG_HIBERNATE).artifactId("hibernate-processor").build())
+        .and()
+      .build();
     // @formatter:on
   }
 }

--- a/src/main/java/com/seed4j/generator/server/springboot/database/jpa/infrastructure/primary/JpaModuleConfiguration.java
+++ b/src/main/java/com/seed4j/generator/server/springboot/database/jpa/infrastructure/primary/JpaModuleConfiguration.java
@@ -6,6 +6,7 @@ import static com.seed4j.shared.slug.domain.Seed4JCoreModuleSlug.DATASOURCE_MSSQ
 import static com.seed4j.shared.slug.domain.Seed4JCoreModuleSlug.DATASOURCE_MYSQL;
 import static com.seed4j.shared.slug.domain.Seed4JCoreModuleSlug.DATASOURCE_POSTGRESQL;
 import static com.seed4j.shared.slug.domain.Seed4JCoreModuleSlug.JPA_MARIADB;
+import static com.seed4j.shared.slug.domain.Seed4JCoreModuleSlug.JPA_METAMODEL_GENERATOR;
 import static com.seed4j.shared.slug.domain.Seed4JCoreModuleSlug.JPA_MSSQL;
 import static com.seed4j.shared.slug.domain.Seed4JCoreModuleSlug.JPA_MYSQL;
 import static com.seed4j.shared.slug.domain.Seed4JCoreModuleSlug.JPA_POSTGRESQL;
@@ -73,6 +74,17 @@ class JpaModuleConfiguration {
       .addProjectBaseName()
       .addSpringConfigurationFormat()
       .build();
+  }
+
+  @Bean
+  Seed4JModuleResource metaModelGeneratorModule(JpaApplicationService jpa) {
+    return Seed4JModuleResource.builder()
+      .slug(JPA_METAMODEL_GENERATOR)
+      .propertiesDefinition(Seed4JModulePropertiesDefinition.EMPTY)
+      .apiDoc(API_DOC_GROUP, "Add JPA metamodel generator to project")
+      .organization(Seed4JModuleOrganization.builder().addDependency(JPA_PERSISTENCE).build())
+      .tags(tags())
+      .factory(jpa::buildMetaModelGenerator);
   }
 
   private static String[] tags() {

--- a/src/main/java/com/seed4j/generator/server/springboot/database/jpa/infrastructure/primary/JpaModuleConfiguration.java
+++ b/src/main/java/com/seed4j/generator/server/springboot/database/jpa/infrastructure/primary/JpaModuleConfiguration.java
@@ -45,7 +45,7 @@ class JpaModuleConfiguration {
   }
 
   @Bean
-  Seed4JModuleResource jpaMmySQLModule(JpaApplicationService mySQL) {
+  Seed4JModuleResource jpaMySQLModule(JpaApplicationService mySQL) {
     return Seed4JModuleResource.builder()
       .slug(JPA_MYSQL)
       .propertiesDefinition(properties())

--- a/src/main/java/com/seed4j/module/domain/Seed4JModule.java
+++ b/src/main/java/com/seed4j/module/domain/Seed4JModule.java
@@ -38,8 +38,12 @@ import com.seed4j.module.domain.javabuildprofile.BuildProfileId;
 import com.seed4j.module.domain.javabuildprofile.Seed4JModuleJavaBuildProfiles;
 import com.seed4j.module.domain.javabuildprofile.Seed4JModuleJavaBuildProfiles.Seed4JModuleJavaBuildProfilesBuilder;
 import com.seed4j.module.domain.javadependency.DependencyId;
+import com.seed4j.module.domain.javadependency.JavaAnnotationProcessorDependency;
+import com.seed4j.module.domain.javadependency.JavaAnnotationProcessorDependency.JavaAnnotationProcessorDependencyGroupIdBuilder;
 import com.seed4j.module.domain.javadependency.JavaDependency;
 import com.seed4j.module.domain.javadependency.JavaDependency.JavaDependencyGroupIdBuilder;
+import com.seed4j.module.domain.javadependency.Seed4JModuleJavaCompiler;
+import com.seed4j.module.domain.javadependency.Seed4JModuleJavaCompiler.Seed4JModuleJavaCompilerBuilder;
 import com.seed4j.module.domain.javadependency.Seed4JModuleJavaDependencies;
 import com.seed4j.module.domain.javadependency.Seed4JModuleJavaDependencies.Seed4JModuleJavaDependenciesBuilder;
 import com.seed4j.module.domain.javaproperties.Comment;
@@ -118,6 +122,7 @@ public final class Seed4JModule {
   private final Seed4JModuleStartupCommands startupCommands;
   private final Seed4JModuleContext context;
   private final Seed4JModuleJavaDependencies javaDependencies;
+  private final Seed4JModuleJavaCompiler javaCompiler;
   private final Seed4JModuleBuildProperties javaBuildProperties;
   private final Seed4JModuleJavaBuildProfiles javaBuildProfiles;
   private final Seed4JModuleMavenPlugins mavenPlugins;
@@ -142,6 +147,7 @@ public final class Seed4JModule {
     startupCommands = builder.startupCommands.build();
     context = builder.context.build();
     javaDependencies = builder.javaDependencies.build();
+    javaCompiler = builder.javaCompiler.build();
     javaBuildProperties = builder.javaBuildProperties.build();
     javaBuildProfiles = builder.javaBuildProfiles.build();
     mavenPlugins = builder.mavenPlugins.build();
@@ -168,6 +174,7 @@ public final class Seed4JModule {
     startupCommands = source.startupCommands;
     context = source.context;
     javaDependencies = source.javaDependencies;
+    javaCompiler = source.javaCompiler;
     javaBuildProperties = source.javaBuildProperties;
     javaBuildProfiles = source.javaBuildProfiles;
     mavenPlugins = source.mavenPlugins;
@@ -242,6 +249,10 @@ public final class Seed4JModule {
 
   public static JavaDependencyGroupIdBuilder javaDependency() {
     return JavaDependency.builder();
+  }
+
+  public static JavaAnnotationProcessorDependencyGroupIdBuilder javaAnnotationProcessorDependency() {
+    return JavaAnnotationProcessorDependency.builder();
   }
 
   public static MavenBuildExtensionGroupIdBuilder mavenBuildExtension() {
@@ -490,6 +501,10 @@ public final class Seed4JModule {
     return javaDependencies;
   }
 
+  public Seed4JModuleJavaCompiler javaCompiler() {
+    return javaCompiler;
+  }
+
   public Seed4JModuleBuildProperties javaBuildProperties() {
     return javaBuildProperties;
   }
@@ -561,6 +576,7 @@ public final class Seed4JModule {
     );
     private final Seed4JModuleStartupCommandsBuilder startupCommands = Seed4JModuleStartupCommands.builder(this);
     private final Seed4JModuleJavaDependenciesBuilder<Seed4JModuleBuilder> javaDependencies = Seed4JModuleJavaDependencies.builder(this);
+    private final Seed4JModuleJavaCompilerBuilder<Seed4JModuleBuilder> javaCompiler = Seed4JModuleJavaCompiler.builder(this);
     private final Seed4JModuleBuildPropertiesBuilder<Seed4JModuleBuilder> javaBuildProperties = Seed4JModuleBuildProperties.builder(this);
     private final Seed4JModuleJavaBuildProfilesBuilder javaBuildProfiles = Seed4JModuleJavaBuildProfiles.builder(this);
     private final Seed4JModuleMavenPluginsBuilder<Seed4JModuleBuilder> mavenPlugins = Seed4JModuleMavenPlugins.builder(this);
@@ -657,6 +673,10 @@ public final class Seed4JModule {
 
     public Seed4JModuleJavaDependenciesBuilder<Seed4JModuleBuilder> javaDependencies() {
       return javaDependencies;
+    }
+
+    public Seed4JModuleJavaCompilerBuilder<Seed4JModuleBuilder> javaCompiler() {
+      return javaCompiler;
     }
 
     public Seed4JModuleBuildPropertiesBuilder<Seed4JModuleBuilder> javaBuildProperties() {

--- a/src/main/java/com/seed4j/module/domain/Seed4JModulesApplyer.java
+++ b/src/main/java/com/seed4j/module/domain/Seed4JModulesApplyer.java
@@ -88,6 +88,7 @@ public class Seed4JModulesApplyer {
       .startupCommands(buildStartupCommands(module))
       .javaBuildCommands(
         buildDependenciesChanges(module)
+          .merge(buildJavaCompilerChanges(module))
           .merge(buildPluginsChanges(module))
           .merge(buildMavenBuildExtensionsChanges(module))
           .merge(buildPropertiesChanges(module))
@@ -192,6 +193,10 @@ public class Seed4JModulesApplyer {
 
   private JavaBuildCommands buildDependenciesChanges(Seed4JModule module) {
     return module.javaDependencies().buildChanges(javaVersions.get(), projectDependencies.get(module.projectFolder()));
+  }
+
+  private JavaBuildCommands buildJavaCompilerChanges(Seed4JModule module) {
+    return module.javaCompiler().buildChanges(javaVersions.get(), projectDependencies.get(module.projectFolder()));
   }
 
   private JavaBuildCommands buildPropertiesChanges(Seed4JModule module) {

--- a/src/main/java/com/seed4j/module/domain/javabuild/command/AddJavaAnnotationProcessor.java
+++ b/src/main/java/com/seed4j/module/domain/javabuild/command/AddJavaAnnotationProcessor.java
@@ -1,0 +1,10 @@
+package com.seed4j.module.domain.javabuild.command;
+
+import com.seed4j.module.domain.javadependency.JavaAnnotationProcessorDependency;
+import com.seed4j.shared.error.domain.Assert;
+
+public record AddJavaAnnotationProcessor(JavaAnnotationProcessorDependency dependency) implements JavaBuildCommand {
+  public AddJavaAnnotationProcessor {
+    Assert.notNull("dependency", dependency);
+  }
+}

--- a/src/main/java/com/seed4j/module/domain/javabuild/command/JavaBuildCommand.java
+++ b/src/main/java/com/seed4j/module/domain/javabuild/command/JavaBuildCommand.java
@@ -2,16 +2,18 @@ package com.seed4j.module.domain.javabuild.command;
 
 public sealed interface JavaBuildCommand
   permits
-    AddMavenPluginManagement,
-    AddDirectMavenPlugin,
     AddDirectJavaDependency,
+    AddDirectMavenPlugin,
+    AddGradleConfiguration,
     AddGradlePlugin,
+    AddGradleTasksTestInstruction,
+    AddJavaAnnotationProcessor,
     AddJavaBuildProfile,
     AddJavaDependencyManagement,
     AddMavenBuildExtension,
+    AddMavenPluginManagement,
     RemoveDirectJavaDependency,
+    RemoveJavaAnnotationProcessor,
     RemoveJavaDependencyManagement,
     SetBuildProperty,
-    SetVersion,
-    AddGradleConfiguration,
-    AddGradleTasksTestInstruction {}
+    SetVersion {}

--- a/src/main/java/com/seed4j/module/domain/javabuild/command/RemoveJavaAnnotationProcessor.java
+++ b/src/main/java/com/seed4j/module/domain/javabuild/command/RemoveJavaAnnotationProcessor.java
@@ -1,0 +1,10 @@
+package com.seed4j.module.domain.javabuild.command;
+
+import com.seed4j.module.domain.javadependency.DependencyId;
+import com.seed4j.shared.error.domain.Assert;
+
+public record RemoveJavaAnnotationProcessor(DependencyId dependency) implements JavaBuildCommand {
+  public RemoveJavaAnnotationProcessor {
+    Assert.notNull("dependency", dependency);
+  }
+}

--- a/src/main/java/com/seed4j/module/domain/javadependency/DependencyId.java
+++ b/src/main/java/com/seed4j/module/domain/javadependency/DependencyId.java
@@ -124,10 +124,18 @@ public final class DependencyId {
 
   public interface DependencyIdGroupIdBuilder {
     DependencyIdArtifactIdBuilder groupId(GroupId groupId);
+
+    default DependencyIdArtifactIdBuilder groupId(String groupId) {
+      return groupId(new GroupId(groupId));
+    }
   }
 
   public interface DependencyIdArtifactIdBuilder {
     DependencyIdOptionalFieldsBuilder artifactId(ArtifactId artifactId);
+
+    default DependencyIdOptionalFieldsBuilder artifactId(String artifactId) {
+      return artifactId(new ArtifactId(artifactId));
+    }
   }
 
   public interface DependencyIdOptionalFieldsBuilder {

--- a/src/main/java/com/seed4j/module/domain/javadependency/JavaAnnotationProcessorDependencies.java
+++ b/src/main/java/com/seed4j/module/domain/javadependency/JavaAnnotationProcessorDependencies.java
@@ -1,0 +1,42 @@
+package com.seed4j.module.domain.javadependency;
+
+import com.seed4j.shared.error.domain.Assert;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class JavaAnnotationProcessorDependencies {
+
+  public static final JavaAnnotationProcessorDependencies EMPTY = new JavaAnnotationProcessorDependencies(List.of());
+
+  private final Map<DependencyId, JavaAnnotationProcessorDependency> dependencies;
+
+  public JavaAnnotationProcessorDependencies(Collection<JavaAnnotationProcessorDependency> dependencies) {
+    this.dependencies = buildDependencies(dependencies);
+  }
+
+  private Map<DependencyId, JavaAnnotationProcessorDependency> buildDependencies(
+    Collection<JavaAnnotationProcessorDependency> dependencies
+  ) {
+    return dependencies.stream().collect(Collectors.toUnmodifiableMap(JavaAnnotationProcessorDependency::id, Function.identity()));
+  }
+
+  public Optional<JavaAnnotationProcessorDependency> get(DependencyId id) {
+    Assert.notNull("id", id);
+
+    return Optional.ofNullable(dependencies.get(id));
+  }
+
+  public JavaAnnotationProcessorDependencies merge(JavaAnnotationProcessorDependencies other) {
+    Assert.notNull("other", other);
+
+    Collection<JavaAnnotationProcessorDependency> mergedDependencies = new ArrayList<>(other.dependencies.values());
+    mergedDependencies.addAll(dependencies.values());
+
+    return new JavaAnnotationProcessorDependencies(mergedDependencies);
+  }
+}

--- a/src/main/java/com/seed4j/module/domain/javadependency/JavaAnnotationProcessorDependency.java
+++ b/src/main/java/com/seed4j/module/domain/javadependency/JavaAnnotationProcessorDependency.java
@@ -1,0 +1,244 @@
+package com.seed4j.module.domain.javadependency;
+
+import com.seed4j.module.domain.javabuild.ArtifactId;
+import com.seed4j.module.domain.javabuild.GroupId;
+import com.seed4j.module.domain.javabuild.VersionSlug;
+import com.seed4j.module.domain.javabuild.command.AddJavaAnnotationProcessor;
+import com.seed4j.module.domain.javabuild.command.JavaBuildCommand;
+import com.seed4j.module.domain.javabuild.command.JavaBuildCommands;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaAnnotationProcessor;
+import com.seed4j.shared.collection.domain.Seed4JCollections;
+import com.seed4j.shared.error.domain.Assert;
+import com.seed4j.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.jspecify.annotations.Nullable;
+
+public final class JavaAnnotationProcessorDependency {
+
+  private final DependencyId id;
+  private final Optional<VersionSlug> versionSlug;
+  private final Collection<DependencyId> exclusions;
+
+  private JavaAnnotationProcessorDependency(JavaAnnotationProcessorDependencyBuilder builder) {
+    id = buildId(builder);
+    versionSlug = Optional.ofNullable(builder.versionSlug);
+    exclusions = Seed4JCollections.immutable(builder.exclusions);
+  }
+
+  private DependencyId buildId(JavaAnnotationProcessorDependencyBuilder builder) {
+    Assert.notNull("groupId", builder.groupId);
+    Assert.notNull("artifactId", builder.artifactId);
+
+    return DependencyId.builder()
+      .groupId(builder.groupId)
+      .artifactId(builder.artifactId)
+      .classifier(builder.classifier)
+      .type(builder.type)
+      .build();
+  }
+
+  public static JavaAnnotationProcessorDependencyGroupIdBuilder builder() {
+    return new JavaAnnotationProcessorDependencyBuilder();
+  }
+
+  public JavaBuildCommands changeCommands(JavaDependenciesVersions currentVersions, ProjectJavaDependencies projectDependencies) {
+    Assert.notNull("currentVersion", currentVersions);
+    Assert.notNull("projectDependencies", projectDependencies);
+
+    Collection<JavaBuildCommand> dependenciesCommands = dependencyCommands(projectDependencies.annotationProcessor(id));
+    Collection<JavaBuildCommand> versionCommands = versionCommands(currentVersions, projectDependencies, dependenciesCommands);
+
+    return new JavaBuildCommands(Stream.of(dependenciesCommands, versionCommands).flatMap(Collection::stream).toList());
+  }
+
+  private Collection<JavaBuildCommand> versionCommands(
+    JavaDependenciesVersions currentVersions,
+    ProjectJavaDependencies projectDependencies,
+    Collection<JavaBuildCommand> dependencyCommands
+  ) {
+    return JavaDependencyVersionCommands.build(
+      version(),
+      currentVersions,
+      projectDependencies,
+      dependencyCommands,
+      AddJavaAnnotationProcessor.class::isInstance
+    );
+  }
+
+  private Collection<JavaBuildCommand> dependencyCommands(Optional<JavaAnnotationProcessorDependency> projectDependency) {
+    return projectDependency.map(toDependenciesCommands()).orElseGet(() -> List.of(new AddJavaAnnotationProcessor(this)));
+  }
+
+  private Function<JavaAnnotationProcessorDependency, Collection<JavaBuildCommand>> toDependenciesCommands() {
+    return projectDependency -> {
+      Optional<VersionSlug> mergedVersion = versionSlug.or(projectDependency::version);
+
+      if (mergedVersion.equals(projectDependency.version())) {
+        return List.of();
+      }
+
+      JavaAnnotationProcessorDependency resultingDependency = builder()
+        .groupId(id.groupId())
+        .artifactId(id.artifactId())
+        .versionSlug(mergedVersion.orElse(null))
+        .classifier(classifier().orElse(null))
+        .type(type().orElse(null))
+        .build();
+
+      return List.of(new RemoveJavaAnnotationProcessor(id()), new AddJavaAnnotationProcessor(resultingDependency));
+    };
+  }
+
+  public DependencyId id() {
+    return id;
+  }
+
+  public Optional<VersionSlug> version() {
+    return versionSlug;
+  }
+
+  public Optional<JavaDependencyClassifier> classifier() {
+    return id.classifier();
+  }
+
+  public Optional<JavaDependencyType> type() {
+    return id.type();
+  }
+
+  public Collection<DependencyId> exclusions() {
+    return exclusions;
+  }
+
+  @Override
+  @ExcludeFromGeneratedCodeCoverage
+  public int hashCode() {
+    return new HashCodeBuilder().append(id).append(versionSlug).hashCode();
+  }
+
+  @Override
+  @ExcludeFromGeneratedCodeCoverage
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    JavaAnnotationProcessorDependency other = (JavaAnnotationProcessorDependency) obj;
+
+    return new EqualsBuilder().append(id, other.id).append(versionSlug, other.versionSlug).isEquals();
+  }
+
+  private static final class JavaAnnotationProcessorDependencyBuilder
+    implements
+      JavaAnnotationProcessorDependencyGroupIdBuilder,
+      JavaAnnotationProcessorDependencyArtifactIdBuilder,
+      JavaAnnotationProcessorDependencyOptionalValueBuilder
+  {
+
+    private @Nullable GroupId groupId;
+    private @Nullable ArtifactId artifactId;
+    private @Nullable VersionSlug versionSlug;
+    private @Nullable JavaDependencyClassifier classifier;
+    private @Nullable JavaDependencyType type;
+    private final Collection<DependencyId> exclusions = new ArrayList<>();
+
+    @Override
+    public JavaAnnotationProcessorDependencyArtifactIdBuilder groupId(GroupId groupId) {
+      this.groupId = groupId;
+
+      return this;
+    }
+
+    @Override
+    public JavaAnnotationProcessorDependencyOptionalValueBuilder artifactId(ArtifactId artifactId) {
+      this.artifactId = artifactId;
+
+      return this;
+    }
+
+    @Override
+    public JavaAnnotationProcessorDependencyOptionalValueBuilder versionSlug(@Nullable VersionSlug versionSlug) {
+      this.versionSlug = versionSlug;
+
+      return this;
+    }
+
+    @Override
+    public JavaAnnotationProcessorDependencyOptionalValueBuilder classifier(@Nullable JavaDependencyClassifier classifier) {
+      this.classifier = classifier;
+
+      return this;
+    }
+
+    @Override
+    public JavaAnnotationProcessorDependencyOptionalValueBuilder type(@Nullable JavaDependencyType type) {
+      this.type = type;
+
+      return this;
+    }
+
+    @Override
+    public JavaAnnotationProcessorDependencyOptionalValueBuilder addExclusion(DependencyId dependency) {
+      Assert.notNull("dependency", dependency);
+
+      exclusions.add(dependency);
+
+      return this;
+    }
+
+    @Override
+    public JavaAnnotationProcessorDependency build() {
+      return new JavaAnnotationProcessorDependency(this);
+    }
+  }
+
+  public interface JavaAnnotationProcessorDependencyGroupIdBuilder {
+    JavaAnnotationProcessorDependencyArtifactIdBuilder groupId(GroupId groupId);
+
+    default JavaAnnotationProcessorDependencyArtifactIdBuilder groupId(String groupId) {
+      return groupId(new GroupId(groupId));
+    }
+  }
+
+  public interface JavaAnnotationProcessorDependencyArtifactIdBuilder {
+    JavaAnnotationProcessorDependencyOptionalValueBuilder artifactId(ArtifactId artifactId);
+
+    default JavaAnnotationProcessorDependencyOptionalValueBuilder artifactId(String artifactId) {
+      return artifactId(new ArtifactId(artifactId));
+    }
+  }
+
+  public interface JavaAnnotationProcessorDependencyOptionalValueBuilder {
+    JavaAnnotationProcessorDependencyOptionalValueBuilder versionSlug(@Nullable VersionSlug versionSlug);
+
+    JavaAnnotationProcessorDependencyOptionalValueBuilder classifier(@Nullable JavaDependencyClassifier classifier);
+
+    JavaAnnotationProcessorDependencyOptionalValueBuilder type(@Nullable JavaDependencyType type);
+
+    JavaAnnotationProcessorDependencyOptionalValueBuilder addExclusion(DependencyId dependency);
+
+    JavaAnnotationProcessorDependency build();
+
+    default JavaAnnotationProcessorDependencyOptionalValueBuilder versionSlug(String versionSlug) {
+      return versionSlug(VersionSlug.of(versionSlug).orElse(null));
+    }
+
+    default JavaAnnotationProcessorDependencyOptionalValueBuilder classifier(String classifier) {
+      return classifier(JavaDependencyClassifier.of(classifier).orElse(null));
+    }
+
+    default JavaAnnotationProcessorDependencyOptionalValueBuilder addExclusion(GroupId groupId, ArtifactId artifactId) {
+      return addExclusion(DependencyId.of(groupId, artifactId));
+    }
+  }
+}

--- a/src/main/java/com/seed4j/module/domain/javadependency/JavaDependency.java
+++ b/src/main/java/com/seed4j/module/domain/javadependency/JavaDependency.java
@@ -7,7 +7,6 @@ import com.seed4j.module.domain.javabuild.VersionSlug;
 import com.seed4j.module.domain.javabuild.command.AddDirectJavaDependency;
 import com.seed4j.module.domain.javabuild.command.AddJavaDependencyManagement;
 import com.seed4j.module.domain.javabuild.command.JavaBuildCommand;
-import com.seed4j.module.domain.javabuild.command.SetVersion;
 import com.seed4j.module.domain.javabuildprofile.BuildProfileId;
 import com.seed4j.shared.collection.domain.Seed4JCollections;
 import com.seed4j.shared.error.domain.Assert;
@@ -60,59 +59,20 @@ public final class JavaDependency {
     ProjectJavaDependencies projectDependencies,
     Collection<JavaBuildCommand> dependencyCommands
   ) {
-    return version()
-      .flatMap(toVersion(currentVersions, projectDependencies, dependencyCommands))
-      .map(toSetVersionCommand())
-      .map(List::of)
-      .orElse(List.of());
+    return JavaDependencyVersionCommands.build(
+      version(),
+      currentVersions,
+      projectDependencies,
+      dependencyCommands,
+      cmd -> cmd instanceof AddDirectJavaDependency || cmd instanceof AddJavaDependencyManagement
+    );
   }
 
   public static Function<VersionSlug, Optional<JavaDependencyVersion>> toVersion(
     JavaDependenciesVersions currentVersions,
     ProjectJavaDependencies projectDependencies
   ) {
-    return toVersion(currentVersions, projectDependencies, List.of());
-  }
-
-  private static Function<VersionSlug, Optional<JavaDependencyVersion>> toVersion(
-    JavaDependenciesVersions currentVersions,
-    ProjectJavaDependencies projectDependencies,
-    Collection<JavaBuildCommand> dependencyCommands
-  ) {
-    return slug -> {
-      JavaDependencyVersion currentVersion = currentVersions.get(slug);
-
-      return projectDependencies
-        .version(slug)
-        .map(toVersionToUse(currentVersion, dependencyCommands))
-        .orElseGet(() -> Optional.of(currentVersion));
-    };
-  }
-
-  private static Function<JavaDependencyVersion, Optional<JavaDependencyVersion>> toVersionToUse(
-    JavaDependencyVersion currentVersion,
-    Collection<JavaBuildCommand> dependencyCommands
-  ) {
-    return version -> {
-      if (version.equals(currentVersion) && hasNoDependencyToAdd(dependencyCommands)) {
-        return Optional.empty();
-      }
-
-      return Optional.of(currentVersion);
-    };
-  }
-
-  private static boolean hasNoDependencyToAdd(Collection<JavaBuildCommand> dependencyCommands) {
-    return dependencyCommands
-      .stream()
-      .noneMatch(
-        dependencyCommand ->
-          dependencyCommand instanceof AddDirectJavaDependency || dependencyCommand instanceof AddJavaDependencyManagement
-      );
-  }
-
-  private Function<JavaDependencyVersion, JavaBuildCommand> toSetVersionCommand() {
-    return SetVersion::new;
+    return JavaDependencyVersionCommands.toVersion(currentVersions, projectDependencies);
   }
 
   Collection<JavaBuildCommand> dependencyCommands(

--- a/src/main/java/com/seed4j/module/domain/javadependency/JavaDependencyVersionCommands.java
+++ b/src/main/java/com/seed4j/module/domain/javadependency/JavaDependencyVersionCommands.java
@@ -1,0 +1,65 @@
+package com.seed4j.module.domain.javadependency;
+
+import com.seed4j.module.domain.javabuild.VersionSlug;
+import com.seed4j.module.domain.javabuild.command.JavaBuildCommand;
+import com.seed4j.module.domain.javabuild.command.SetVersion;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+final class JavaDependencyVersionCommands {
+
+  private JavaDependencyVersionCommands() {}
+
+  static Collection<JavaBuildCommand> build(
+    Optional<VersionSlug> version,
+    JavaDependenciesVersions currentVersions,
+    ProjectJavaDependencies projectDependencies,
+    Collection<JavaBuildCommand> dependencyCommands,
+    Predicate<JavaBuildCommand> isAddCommand
+  ) {
+    return version
+      .flatMap(toVersion(currentVersions, projectDependencies, dependencyCommands, isAddCommand))
+      .map(v -> List.<JavaBuildCommand>of(new SetVersion(v)))
+      .orElse(List.of());
+  }
+
+  static Function<VersionSlug, Optional<JavaDependencyVersion>> toVersion(
+    JavaDependenciesVersions currentVersions,
+    ProjectJavaDependencies projectDependencies
+  ) {
+    return toVersion(currentVersions, projectDependencies, List.of(), _ -> false);
+  }
+
+  private static Function<VersionSlug, Optional<JavaDependencyVersion>> toVersion(
+    JavaDependenciesVersions currentVersions,
+    ProjectJavaDependencies projectDependencies,
+    Collection<JavaBuildCommand> dependencyCommands,
+    Predicate<JavaBuildCommand> isAddCommand
+  ) {
+    return slug -> {
+      JavaDependencyVersion currentVersion = currentVersions.get(slug);
+
+      return projectDependencies
+        .version(slug)
+        .map(toVersionToUse(currentVersion, dependencyCommands, isAddCommand))
+        .orElseGet(() -> Optional.of(currentVersion));
+    };
+  }
+
+  private static Function<JavaDependencyVersion, Optional<JavaDependencyVersion>> toVersionToUse(
+    JavaDependencyVersion currentVersion,
+    Collection<JavaBuildCommand> dependencyCommands,
+    Predicate<JavaBuildCommand> isAddCommand
+  ) {
+    return version -> {
+      if (version.equals(currentVersion) && dependencyCommands.stream().noneMatch(isAddCommand)) {
+        return Optional.empty();
+      }
+
+      return Optional.of(currentVersion);
+    };
+  }
+}

--- a/src/main/java/com/seed4j/module/domain/javadependency/ProjectJavaDependencies.java
+++ b/src/main/java/com/seed4j/module/domain/javadependency/ProjectJavaDependencies.java
@@ -9,25 +9,25 @@ public final class ProjectJavaDependencies {
 
   public static final ProjectJavaDependencies EMPTY = builder()
     .versions(ProjectJavaDependenciesVersions.EMPTY)
-    .dependenciesManagements(JavaDependencies.EMPTY)
-    .dependencies(JavaDependencies.EMPTY);
+    .dependenciesManagement(JavaDependencies.EMPTY)
+    .dependencies(JavaDependencies.EMPTY)
+    .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
 
   private final ProjectJavaDependenciesVersions versions;
   private final JavaDependencies dependenciesManagement;
   private final JavaDependencies dependencies;
+  private final JavaAnnotationProcessorDependencies annotationProcessingDependencies;
 
   private ProjectJavaDependencies(ProjectJavaDependenciesBuilder builder) {
     Assert.notNull("versions", builder.versions);
     Assert.notNull("dependenciesManagement", builder.dependenciesManagement);
     Assert.notNull("dependencies", builder.dependencies);
+    Assert.notNull("annotationProcessingDependencies", builder.annotationProcessingDependencies);
 
     versions = builder.versions;
     dependenciesManagement = builder.dependenciesManagement;
     dependencies = builder.dependencies;
-  }
-
-  public static ProjectJavaDependenciesVersionsBuilder builder() {
-    return new ProjectJavaDependenciesBuilder();
+    annotationProcessingDependencies = builder.annotationProcessingDependencies;
   }
 
   public Optional<JavaDependencyVersion> version(VersionSlug slug) {
@@ -40,6 +40,10 @@ public final class ProjectJavaDependencies {
 
   public Optional<JavaDependency> dependencyManagement(DependencyId id) {
     return dependenciesManagement.get(id);
+  }
+
+  public Optional<JavaAnnotationProcessorDependency> annotationProcessor(DependencyId id) {
+    return annotationProcessingDependencies.get(id);
   }
 
   public ProjectJavaDependenciesVersions versions() {
@@ -59,20 +63,43 @@ public final class ProjectJavaDependencies {
 
     return builder()
       .versions(versions.merge(other.versions()))
-      .dependenciesManagements(dependenciesManagement.merge(other.dependenciesManagement))
-      .dependencies(dependencies.merge(other.dependencies));
+      .dependenciesManagement(dependenciesManagement.merge(other.dependenciesManagement))
+      .dependencies(dependencies.merge(other.dependencies))
+      .annotationProcessingDependencies(annotationProcessingDependencies.merge(other.annotationProcessingDependencies));
+  }
+
+  public static ProjectJavaDependenciesVersionsBuilder builder() {
+    return new ProjectJavaDependenciesBuilder();
+  }
+
+  public sealed interface ProjectJavaDependenciesVersionsBuilder permits ProjectJavaDependenciesBuilder {
+    ProjectJavaDependenciesDependenciesManagementBuilder versions(ProjectJavaDependenciesVersions versions);
+  }
+
+  public sealed interface ProjectJavaDependenciesDependenciesManagementBuilder permits ProjectJavaDependenciesBuilder {
+    ProjectJavaDependenciesDependenciesBuilder dependenciesManagement(JavaDependencies dependenciesManagement);
+  }
+
+  public sealed interface ProjectJavaDependenciesDependenciesBuilder permits ProjectJavaDependenciesBuilder {
+    ProjectJavaDependenciesAnnotationProcessingDependenciesBuilder dependencies(JavaDependencies dependencies);
+  }
+
+  public sealed interface ProjectJavaDependenciesAnnotationProcessingDependenciesBuilder permits ProjectJavaDependenciesBuilder {
+    ProjectJavaDependencies annotationProcessingDependencies(JavaAnnotationProcessorDependencies annotationProcessingDependencies);
   }
 
   private static final class ProjectJavaDependenciesBuilder
     implements
       ProjectJavaDependenciesVersionsBuilder,
       ProjectJavaDependenciesDependenciesManagementBuilder,
-      ProjectJavaDependenciesDependenciesBuilder
+      ProjectJavaDependenciesDependenciesBuilder,
+      ProjectJavaDependenciesAnnotationProcessingDependenciesBuilder
   {
 
     private @Nullable ProjectJavaDependenciesVersions versions;
     private @Nullable JavaDependencies dependenciesManagement;
     private @Nullable JavaDependencies dependencies;
+    private @Nullable JavaAnnotationProcessorDependencies annotationProcessingDependencies;
 
     @Override
     public ProjectJavaDependenciesDependenciesManagementBuilder versions(ProjectJavaDependenciesVersions versions) {
@@ -82,29 +109,24 @@ public final class ProjectJavaDependencies {
     }
 
     @Override
-    public ProjectJavaDependenciesDependenciesBuilder dependenciesManagements(JavaDependencies dependenciesManagement) {
+    public ProjectJavaDependenciesDependenciesBuilder dependenciesManagement(JavaDependencies dependenciesManagement) {
       this.dependenciesManagement = dependenciesManagement;
 
       return this;
     }
 
     @Override
-    public ProjectJavaDependencies dependencies(JavaDependencies dependencies) {
+    public ProjectJavaDependenciesAnnotationProcessingDependenciesBuilder dependencies(JavaDependencies dependencies) {
       this.dependencies = dependencies;
+
+      return this;
+    }
+
+    @Override
+    public ProjectJavaDependencies annotationProcessingDependencies(JavaAnnotationProcessorDependencies annotationProcessingDependencies) {
+      this.annotationProcessingDependencies = annotationProcessingDependencies;
 
       return new ProjectJavaDependencies(this);
     }
-  }
-
-  public interface ProjectJavaDependenciesVersionsBuilder {
-    ProjectJavaDependenciesDependenciesManagementBuilder versions(ProjectJavaDependenciesVersions versions);
-  }
-
-  public interface ProjectJavaDependenciesDependenciesManagementBuilder {
-    ProjectJavaDependenciesDependenciesBuilder dependenciesManagements(JavaDependencies dependenciesManagement);
-  }
-
-  public interface ProjectJavaDependenciesDependenciesBuilder {
-    ProjectJavaDependencies dependencies(JavaDependencies dependencies);
   }
 }

--- a/src/main/java/com/seed4j/module/domain/javadependency/Seed4JModuleJavaCompiler.java
+++ b/src/main/java/com/seed4j/module/domain/javadependency/Seed4JModuleJavaCompiler.java
@@ -1,0 +1,88 @@
+package com.seed4j.module.domain.javadependency;
+
+import com.seed4j.module.domain.javabuild.command.JavaBuildCommands;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaAnnotationProcessor;
+import com.seed4j.shared.error.domain.Assert;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public final class Seed4JModuleJavaCompiler {
+
+  private final Collection<JavaAnnotationProcessorDependency> annotationProcessingDependencies;
+  private final Collection<DependencyId> annotationProcessingDependenciesToRemove;
+
+  private Seed4JModuleJavaCompiler(Seed4JModuleJavaCompilerBuilder<?> builder) {
+    annotationProcessingDependencies = builder.annotationProcessingDependencies;
+    annotationProcessingDependenciesToRemove = builder.annotationProcessingDependenciesToRemove;
+  }
+
+  public static <M> Seed4JModuleJavaCompilerBuilder<M> builder(M module) {
+    return new Seed4JModuleJavaCompilerBuilder<>(module);
+  }
+
+  public JavaBuildCommands buildChanges(JavaDependenciesVersions versions, ProjectJavaDependencies projectDependencies) {
+    Assert.notNull("versions", versions);
+    Assert.notNull("projectDependencies", projectDependencies);
+
+    return Stream.of(
+      annotationProcessingDependenciesToRemoveCommands(),
+      annotationProcessingDependenciesChanges(versions, projectDependencies)
+    )
+      .flatMap(Function.identity())
+      .reduce(JavaBuildCommands.EMPTY, JavaBuildCommands::merge);
+  }
+
+  private Stream<JavaBuildCommands> annotationProcessingDependenciesToRemoveCommands() {
+    return Stream.of(
+      new JavaBuildCommands(annotationProcessingDependenciesToRemove.stream().map(RemoveJavaAnnotationProcessor::new).toList())
+    );
+  }
+
+  private Stream<JavaBuildCommands> annotationProcessingDependenciesChanges(
+    JavaDependenciesVersions currentVersions,
+    ProjectJavaDependencies projectDependencies
+  ) {
+    return annotationProcessingDependencies.stream().map(dependency -> dependency.changeCommands(currentVersions, projectDependencies));
+  }
+
+  public static final class Seed4JModuleJavaCompilerBuilder<T> {
+
+    private static final String DEPENDENCY = "dependency";
+
+    private final T parentModuleBuilder;
+    private final Collection<JavaAnnotationProcessorDependency> annotationProcessingDependencies = new ArrayList<>();
+    private final Collection<DependencyId> annotationProcessingDependenciesToRemove = new ArrayList<>();
+
+    private Seed4JModuleJavaCompilerBuilder(T parentModuleBuilder) {
+      Assert.notNull("module", parentModuleBuilder);
+
+      this.parentModuleBuilder = parentModuleBuilder;
+    }
+
+    public Seed4JModuleJavaCompilerBuilder<T> addAnnotationProcessor(JavaAnnotationProcessorDependency dependency) {
+      Assert.notNull(DEPENDENCY, dependency);
+
+      annotationProcessingDependencies.add(dependency);
+
+      return this;
+    }
+
+    public Seed4JModuleJavaCompilerBuilder<T> removeAnnotationProcessor(DependencyId dependency) {
+      Assert.notNull(DEPENDENCY, dependency);
+
+      annotationProcessingDependenciesToRemove.add(dependency);
+
+      return this;
+    }
+
+    public T and() {
+      return parentModuleBuilder;
+    }
+
+    public Seed4JModuleJavaCompiler build() {
+      return new Seed4JModuleJavaCompiler(this);
+    }
+  }
+}

--- a/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/FileSystemJavaBuildCommandsHandler.java
+++ b/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/FileSystemJavaBuildCommandsHandler.java
@@ -4,7 +4,23 @@ import com.seed4j.module.domain.Indentation;
 import com.seed4j.module.domain.Seed4JModuleContext;
 import com.seed4j.module.domain.javabuild.JavaBuildTool;
 import com.seed4j.module.domain.javabuild.ProjectJavaBuildToolRepository;
-import com.seed4j.module.domain.javabuild.command.*;
+import com.seed4j.module.domain.javabuild.command.AddDirectJavaDependency;
+import com.seed4j.module.domain.javabuild.command.AddDirectMavenPlugin;
+import com.seed4j.module.domain.javabuild.command.AddGradleConfiguration;
+import com.seed4j.module.domain.javabuild.command.AddGradlePlugin;
+import com.seed4j.module.domain.javabuild.command.AddGradleTasksTestInstruction;
+import com.seed4j.module.domain.javabuild.command.AddJavaAnnotationProcessor;
+import com.seed4j.module.domain.javabuild.command.AddJavaBuildProfile;
+import com.seed4j.module.domain.javabuild.command.AddJavaDependencyManagement;
+import com.seed4j.module.domain.javabuild.command.AddMavenBuildExtension;
+import com.seed4j.module.domain.javabuild.command.AddMavenPluginManagement;
+import com.seed4j.module.domain.javabuild.command.JavaBuildCommand;
+import com.seed4j.module.domain.javabuild.command.JavaBuildCommands;
+import com.seed4j.module.domain.javabuild.command.RemoveDirectJavaDependency;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaAnnotationProcessor;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaDependencyManagement;
+import com.seed4j.module.domain.javabuild.command.SetBuildProperty;
+import com.seed4j.module.domain.javabuild.command.SetVersion;
 import com.seed4j.module.domain.properties.Seed4JProjectFolder;
 import com.seed4j.module.infrastructure.secondary.FileSystemReplacer;
 import com.seed4j.module.infrastructure.secondary.FileSystemSeed4JModuleFiles;
@@ -74,6 +90,8 @@ public class FileSystemJavaBuildCommandsHandler {
       case AddGradlePlugin addGradlePlugin -> handler.handle(addGradlePlugin);
       case AddGradleConfiguration addGradleConfiguration -> handler.handle(addGradleConfiguration);
       case AddGradleTasksTestInstruction addGradleTasksTestInstruction -> handler.handle(addGradleTasksTestInstruction);
+      case AddJavaAnnotationProcessor addJavaAnnotationProcessor -> handler.handle(addJavaAnnotationProcessor);
+      case RemoveJavaAnnotationProcessor removeJavaAnnotationProcessor -> handler.handle(removeJavaAnnotationProcessor);
     }
   }
 }

--- a/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/JavaDependenciesCommandHandler.java
+++ b/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/JavaDependenciesCommandHandler.java
@@ -1,6 +1,20 @@
 package com.seed4j.module.infrastructure.secondary.javadependency;
 
-import com.seed4j.module.domain.javabuild.command.*;
+import com.seed4j.module.domain.javabuild.command.AddDirectJavaDependency;
+import com.seed4j.module.domain.javabuild.command.AddDirectMavenPlugin;
+import com.seed4j.module.domain.javabuild.command.AddGradleConfiguration;
+import com.seed4j.module.domain.javabuild.command.AddGradlePlugin;
+import com.seed4j.module.domain.javabuild.command.AddGradleTasksTestInstruction;
+import com.seed4j.module.domain.javabuild.command.AddJavaAnnotationProcessor;
+import com.seed4j.module.domain.javabuild.command.AddJavaBuildProfile;
+import com.seed4j.module.domain.javabuild.command.AddJavaDependencyManagement;
+import com.seed4j.module.domain.javabuild.command.AddMavenBuildExtension;
+import com.seed4j.module.domain.javabuild.command.AddMavenPluginManagement;
+import com.seed4j.module.domain.javabuild.command.RemoveDirectJavaDependency;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaAnnotationProcessor;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaDependencyManagement;
+import com.seed4j.module.domain.javabuild.command.SetBuildProperty;
+import com.seed4j.module.domain.javabuild.command.SetVersion;
 
 public interface JavaDependenciesCommandHandler {
   void handle(SetVersion command);
@@ -11,9 +25,13 @@ public interface JavaDependenciesCommandHandler {
 
   void handle(RemoveJavaDependencyManagement command);
 
+  void handle(RemoveJavaAnnotationProcessor command);
+
   void handle(AddJavaDependencyManagement command);
 
   void handle(AddDirectMavenPlugin command);
+
+  void handle(AddJavaAnnotationProcessor command);
 
   void handle(AddMavenPluginManagement command);
 

--- a/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandler.java
+++ b/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandler.java
@@ -372,6 +372,14 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
       command.buildProfile().isPresent(),
       gradleDependencyScope(command.dependency())
     );
+    if (command.dependency().scope() == JavaDependencyScope.IMPORT && command.buildProfile().isEmpty()) {
+      addDependencyToBuildGradle(
+        command.dependency(),
+        buildGradleFile(Optional.empty()),
+        false,
+        GradleDependencyScope.ANNOTATION_PROCESSING
+      );
+    }
   }
 
   @Override

--- a/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandler.java
+++ b/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandler.java
@@ -31,16 +31,20 @@ import com.seed4j.module.domain.javabuild.command.AddDirectMavenPlugin;
 import com.seed4j.module.domain.javabuild.command.AddGradleConfiguration;
 import com.seed4j.module.domain.javabuild.command.AddGradlePlugin;
 import com.seed4j.module.domain.javabuild.command.AddGradleTasksTestInstruction;
+import com.seed4j.module.domain.javabuild.command.AddJavaAnnotationProcessor;
 import com.seed4j.module.domain.javabuild.command.AddJavaBuildProfile;
 import com.seed4j.module.domain.javabuild.command.AddJavaDependencyManagement;
 import com.seed4j.module.domain.javabuild.command.AddMavenBuildExtension;
 import com.seed4j.module.domain.javabuild.command.AddMavenPluginManagement;
 import com.seed4j.module.domain.javabuild.command.RemoveDirectJavaDependency;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaAnnotationProcessor;
 import com.seed4j.module.domain.javabuild.command.RemoveJavaDependencyManagement;
 import com.seed4j.module.domain.javabuild.command.SetBuildProperty;
 import com.seed4j.module.domain.javabuild.command.SetVersion;
 import com.seed4j.module.domain.javabuildprofile.BuildProfileActivation;
 import com.seed4j.module.domain.javabuildprofile.BuildProfileId;
+import com.seed4j.module.domain.javadependency.DependencyId;
+import com.seed4j.module.domain.javadependency.JavaAnnotationProcessorDependency;
 import com.seed4j.module.domain.javadependency.JavaDependency;
 import com.seed4j.module.domain.javadependency.JavaDependencyScope;
 import com.seed4j.module.domain.properties.Seed4JProjectFolder;
@@ -93,6 +97,10 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
   );
   private static final Pattern GRADLE_TEST_DEPENDENCY_NEEDLE = Pattern.compile(
     "^\\s+// seed4j-needle-gradle-test-dependencies$",
+    Pattern.MULTILINE
+  );
+  private static final Pattern GRADLE_ANNOTATION_PROCESSING_DEPENDENCY_NEEDLE = Pattern.compile(
+    "^\\s+// seed4j-needle-gradle-annotation-processors$",
     Pattern.MULTILINE
   );
   private static final Pattern GRADLE_PROFILE_ACTIVATION_NEEDLE = Pattern.compile(
@@ -151,17 +159,56 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
   }
 
   @Override
+  public void handle(AddJavaAnnotationProcessor command) {
+    Assert.notNull(COMMAND, command);
+
+    versionsCatalog.addLibrary(command.dependency());
+    addAnnotationProcessorToBuildGradle(command.dependency());
+  }
+
+  private void addAnnotationProcessorToBuildGradle(JavaAnnotationProcessorDependency dependency) {
+    String catalogRef = "libs.%s".formatted(applyVersionCatalogReferenceConvention(libraryAlias(dependency)));
+    StringBuilder dependencyDeclaration = new StringBuilder()
+      .append(indentation.times(1))
+      .append(GradleDependencyScope.ANNOTATION_PROCESSING.command())
+      .append("(")
+      .append(catalogRef)
+      .append(")");
+    appendExclusionBlock(dependencyDeclaration, dependency.exclusions());
+    MandatoryReplacer replacer = new MandatoryReplacer(
+      new RegexNeedleBeforeReplacer(
+        (contentBeforeReplacement, newText) -> !contentBeforeReplacement.contains(newText),
+        GRADLE_ANNOTATION_PROCESSING_DEPENDENCY_NEEDLE
+      ),
+      dependencyDeclaration.toString()
+    );
+    fileReplacer.handle(
+      projectFolder,
+      ContentReplacers.of(new MandatoryFileReplacer(projectFolderRelativePathFrom(buildGradleFile(Optional.empty())), replacer)),
+      context
+    );
+  }
+
+  @Override
   public void handle(AddDirectJavaDependency command) {
     Assert.notNull(COMMAND, command);
 
     versionsCatalog.addLibrary(command.dependency());
-    addDependencyToBuildGradle(command.dependency(), buildGradleFile(command.buildProfile()), command.buildProfile().isPresent());
+    addDependencyToBuildGradle(
+      command.dependency(),
+      buildGradleFile(command.buildProfile()),
+      command.buildProfile().isPresent(),
+      gradleDependencyScope(command.dependency())
+    );
   }
 
-  private void addDependencyToBuildGradle(JavaDependency dependency, Path buildGradleFile, boolean forBuildProfile) {
-    GradleDependencyScope gradleScope = gradleDependencyScope(dependency);
-
-    String dependencyDeclaration = dependencyDeclaration(dependency, forBuildProfile);
+  private void addDependencyToBuildGradle(
+    JavaDependency dependency,
+    Path buildGradleFile,
+    boolean forBuildProfile,
+    GradleDependencyScope gradleScope
+  ) {
+    String dependencyDeclaration = dependencyDeclaration(dependency, gradleScope, forBuildProfile);
     MandatoryReplacer replacer = new MandatoryReplacer(
       new RegexNeedleBeforeReplacer(
         (contentBeforeReplacement, newText) -> !contentBeforeReplacement.contains(newText),
@@ -182,14 +229,12 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
       case GradleDependencyScope.COMPILE_ONLY -> GRADLE_COMPILE_DEPENDENCY_NEEDLE;
       case GradleDependencyScope.RUNTIME_ONLY -> GRADLE_RUNTIME_DEPENDENCY_NEEDLE;
       case GradleDependencyScope.TEST_IMPLEMENTATION -> GRADLE_TEST_DEPENDENCY_NEEDLE;
+      case GradleDependencyScope.ANNOTATION_PROCESSING -> GRADLE_ANNOTATION_PROCESSING_DEPENDENCY_NEEDLE;
     };
   }
 
-  private String dependencyDeclaration(JavaDependency dependency, boolean forBuildProfile) {
-    StringBuilder dependencyDeclaration = new StringBuilder()
-      .append(indentation.times(1))
-      .append(gradleDependencyScope(dependency).command())
-      .append("(");
+  private String dependencyDeclaration(JavaDependency dependency, GradleDependencyScope gradleScope, boolean forBuildProfile) {
+    StringBuilder dependencyDeclaration = new StringBuilder().append(indentation.times(1)).append(gradleScope.command()).append("(");
     var versionCatalogReference = forBuildProfile
       ? versionCatalogReferenceForBuildProfile(dependency)
       : versionCatalogReference(dependency);
@@ -200,9 +245,15 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
     }
     dependencyDeclaration.append(")");
 
-    if (!dependency.exclusions().isEmpty()) {
+    appendExclusionBlock(dependencyDeclaration, dependency.exclusions());
+
+    return dependencyDeclaration.toString();
+  }
+
+  private void appendExclusionBlock(StringBuilder dependencyDeclaration, java.util.Collection<DependencyId> exclusions) {
+    if (!exclusions.isEmpty()) {
       dependencyDeclaration.append(" {");
-      for (var exclusion : dependency.exclusions()) {
+      for (var exclusion : exclusions) {
         dependencyDeclaration.append(LINE_BREAK);
         dependencyDeclaration
           .append(indentation.times(2))
@@ -211,8 +262,6 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
       dependencyDeclaration.append(LINE_BREAK);
       dependencyDeclaration.append(indentation.times(1)).append("}");
     }
-
-    return dependencyDeclaration.toString();
   }
 
   private static String versionCatalogReferenceForBuildProfile(JavaDependency dependency) {
@@ -232,7 +281,7 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
       case TEST -> GradleDependencyScope.TEST_IMPLEMENTATION;
       case PROVIDED -> GradleDependencyScope.COMPILE_ONLY;
       case RUNTIME -> GradleDependencyScope.RUNTIME_ONLY;
-      default -> GradleDependencyScope.IMPLEMENTATION;
+      case COMPILE, IMPORT, SYSTEM -> GradleDependencyScope.IMPLEMENTATION;
     };
   }
 
@@ -293,6 +342,16 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
   }
 
   @Override
+  public void handle(RemoveJavaAnnotationProcessor command) {
+    versionsCatalog
+      .retrieveDependencySlugsFrom(command.dependency())
+      .forEach(dependencySlug -> {
+        removeDependencyFromBuildGradle(dependencySlug, Optional.empty());
+        versionsCatalog.removeLibrary(command.dependency());
+      });
+  }
+
+  @Override
   public void handle(RemoveJavaDependencyManagement command) {
     versionsCatalog
       .retrieveDependencySlugsFrom(command.dependency())
@@ -307,7 +366,12 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
   @Override
   public void handle(AddJavaDependencyManagement command) {
     versionsCatalog.addLibrary(command.dependency());
-    addDependencyToBuildGradle(command.dependency(), buildGradleFile(command.buildProfile()), command.buildProfile().isPresent());
+    addDependencyToBuildGradle(
+      command.dependency(),
+      buildGradleFile(command.buildProfile()),
+      command.buildProfile().isPresent(),
+      gradleDependencyScope(command.dependency())
+    );
   }
 
   @Override
@@ -479,7 +543,12 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
           command.buildProfile()
         );
         versionsCatalog.addLibrary(dependencyFrom(plugin));
-        addDependencyToBuildGradle(dependencyFrom(plugin), projectFolder.filePath(PLUGIN_BUILD_GRADLE_FILE), false);
+        addDependencyToBuildGradle(
+          dependencyFrom(plugin),
+          projectFolder.filePath(PLUGIN_BUILD_GRADLE_FILE),
+          false,
+          gradleDependencyScope(dependencyFrom(plugin))
+        );
       }
     }
     command

--- a/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/gradle/GradleDependencyScope.java
+++ b/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/gradle/GradleDependencyScope.java
@@ -4,7 +4,8 @@ enum GradleDependencyScope {
   IMPLEMENTATION("implementation"),
   COMPILE_ONLY("compileOnly"),
   RUNTIME_ONLY("runtimeOnly"),
-  TEST_IMPLEMENTATION("testImplementation");
+  TEST_IMPLEMENTATION("testImplementation"),
+  ANNOTATION_PROCESSING("annotationProcessor");
 
   private final String command;
 

--- a/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/gradle/VersionsCatalog.java
+++ b/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/gradle/VersionsCatalog.java
@@ -10,6 +10,7 @@ import com.seed4j.module.domain.gradleplugin.GradlePluginSlug;
 import com.seed4j.module.domain.javabuild.DependencySlug;
 import com.seed4j.module.domain.javabuild.VersionSlug;
 import com.seed4j.module.domain.javadependency.DependencyId;
+import com.seed4j.module.domain.javadependency.JavaAnnotationProcessorDependency;
 import com.seed4j.module.domain.javadependency.JavaDependency;
 import com.seed4j.module.domain.javadependency.JavaDependencyVersion;
 import com.seed4j.module.domain.properties.Seed4JProjectFolder;
@@ -27,6 +28,7 @@ public class VersionsCatalog {
   private static final String LIBRARIES_TOML_KEY = "libraries";
   private static final String PLUGINS_TOML_KEY = "plugins";
   private static final String VERSION_REF = "version.ref";
+  private static final String GROUP_ATTRIBUTE = "group";
 
   private final FileConfig tomlConfigFile;
 
@@ -73,7 +75,21 @@ public class VersionsCatalog {
 
   public void addLibrary(JavaDependency dependency) {
     Config libraryConfig = Config.inMemory();
-    libraryConfig.set("group", dependency.id().groupId().get());
+    libraryConfig.set(GROUP_ATTRIBUTE, dependency.id().groupId().get());
+    libraryConfig.set("name", dependency.id().artifactId().get());
+    dependency.version().ifPresent(versionSlug -> libraryConfig.set(VERSION_REF, versionSlug.slug()));
+    String libraryEntryKey = libraryAlias(dependency);
+    tomlConfigFile.set(List.of(LIBRARIES_TOML_KEY, libraryEntryKey), libraryConfig);
+    save();
+  }
+
+  public static String libraryAlias(JavaAnnotationProcessorDependency dependency) {
+    return StringUtils.uncapitalize(dependency.id().artifactId().get());
+  }
+
+  public void addLibrary(JavaAnnotationProcessorDependency dependency) {
+    Config libraryConfig = Config.inMemory();
+    libraryConfig.set(GROUP_ATTRIBUTE, dependency.id().groupId().get());
     libraryConfig.set("name", dependency.id().artifactId().get());
     dependency.version().ifPresent(versionSlug -> libraryConfig.set(VERSION_REF, versionSlug.slug()));
     String libraryEntryKey = libraryAlias(dependency);
@@ -144,7 +160,7 @@ public class VersionsCatalog {
 
   private static Predicate<Entry> groupShouldMatch(DependencyId dependency) {
     return libraryConfig -> {
-      Object groupProperty = ((Config) libraryConfig.getValue()).get("group");
+      Object groupProperty = ((Config) libraryConfig.getValue()).get(GROUP_ATTRIBUTE);
       return dependency.groupId().get().equals(groupProperty);
     };
   }

--- a/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/maven/MavenCommandHandler.java
+++ b/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/maven/MavenCommandHandler.java
@@ -11,18 +11,21 @@ import com.seed4j.module.domain.javabuild.command.AddDirectMavenPlugin;
 import com.seed4j.module.domain.javabuild.command.AddGradleConfiguration;
 import com.seed4j.module.domain.javabuild.command.AddGradlePlugin;
 import com.seed4j.module.domain.javabuild.command.AddGradleTasksTestInstruction;
+import com.seed4j.module.domain.javabuild.command.AddJavaAnnotationProcessor;
 import com.seed4j.module.domain.javabuild.command.AddJavaBuildProfile;
 import com.seed4j.module.domain.javabuild.command.AddJavaDependencyManagement;
 import com.seed4j.module.domain.javabuild.command.AddMavenBuildExtension;
 import com.seed4j.module.domain.javabuild.command.AddMavenPlugin;
 import com.seed4j.module.domain.javabuild.command.AddMavenPluginManagement;
 import com.seed4j.module.domain.javabuild.command.RemoveDirectJavaDependency;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaAnnotationProcessor;
 import com.seed4j.module.domain.javabuild.command.RemoveJavaDependencyManagement;
 import com.seed4j.module.domain.javabuild.command.SetBuildProperty;
 import com.seed4j.module.domain.javabuild.command.SetVersion;
 import com.seed4j.module.domain.javabuildprofile.BuildProfileActivation;
 import com.seed4j.module.domain.javabuildprofile.BuildProfileId;
 import com.seed4j.module.domain.javadependency.DependencyId;
+import com.seed4j.module.domain.javadependency.JavaAnnotationProcessorDependency;
 import com.seed4j.module.domain.javadependency.JavaDependency;
 import com.seed4j.module.domain.javadependency.JavaDependencyClassifier;
 import com.seed4j.module.domain.javadependency.JavaDependencyScope;
@@ -40,6 +43,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -66,6 +70,7 @@ import org.jspecify.annotations.Nullable;
 public class MavenCommandHandler implements JavaDependenciesCommandHandler {
 
   private static final String COMMAND = "command";
+  private static final String ANNOTATION_PROCESSOR_PATHS_NODE = "annotationProcessorPaths";
 
   private final XMLFormat xmlFormat;
   private final Path pomPath;
@@ -259,6 +264,116 @@ public class MavenCommandHandler implements JavaDependenciesCommandHandler {
     extension.setGroupId(mavenBuildExtension.groupId().get());
     mavenBuildExtension.versionSlug().map(VersionSlug::mavenVariable).ifPresent(extension::setVersion);
     return extension;
+  }
+
+  @Override
+  public void handle(AddJavaAnnotationProcessor command) {
+    Assert.notNull(COMMAND, command);
+
+    List<Plugin> managedPlugins = Optional.ofNullable(pomModel.getBuild())
+      .map(Build::getPluginManagement)
+      .map(PluginManagement::getPlugins)
+      .orElse(List.of());
+    Plugin compilerPlugin = findCompilerPlugin(managedPlugins)
+      .or(() -> findCompilerPlugin(pomModel.getBuild().getPlugins()))
+      .orElseThrow(() ->
+        GeneratorException.technicalError("maven-compiler-plugin should already be declared to add annotation processor dependencies")
+      );
+
+    Xpp3Dom compilerConfiguration = Optional.ofNullable(compilerPlugin.getConfiguration())
+      .map(Xpp3Dom.class::cast)
+      .orElseGet(() -> new Xpp3Dom("configuration"));
+    compilerPlugin.setConfiguration(compilerConfiguration);
+
+    addAnnotationProcessorPathToCompilerConfiguration(command.dependency(), compilerConfiguration);
+    writePom();
+  }
+
+  private Optional<Plugin> findCompilerPlugin(List<Plugin> plugins) {
+    return plugins
+      .stream()
+      .filter(plugin -> plugin.getArtifactId().equals("maven-compiler-plugin"))
+      .findFirst();
+  }
+
+  private void addAnnotationProcessorPathToCompilerConfiguration(
+    JavaAnnotationProcessorDependency annotationProcessorDependency,
+    Xpp3Dom compilerConfiguration
+  ) {
+    Xpp3Dom annotationProcessorPaths = compilerConfiguration.getChild(ANNOTATION_PROCESSOR_PATHS_NODE);
+    if (annotationProcessorPaths == null) {
+      annotationProcessorPaths = new Xpp3Dom(ANNOTATION_PROCESSOR_PATHS_NODE);
+      compilerConfiguration.addChild(annotationProcessorPaths);
+    }
+    boolean alreadyPresent = Arrays.stream(annotationProcessorPaths.getChildren("path")).anyMatch(
+      path ->
+        annotationProcessorDependency.id().groupId().get().equals(path.getChild("groupId").getValue())
+        && annotationProcessorDependency.id().artifactId().get().equals(path.getChild("artifactId").getValue())
+    );
+    if (!alreadyPresent) {
+      annotationProcessorPaths.addChild(toAnnotationProcessorPath(annotationProcessorDependency));
+    }
+  }
+
+  private Xpp3Dom toAnnotationProcessorPath(JavaAnnotationProcessorDependency annotationProcessorDependency) {
+    Xpp3Dom path = new Xpp3Dom("path");
+    Xpp3Dom groupId = new Xpp3Dom("groupId");
+    groupId.setValue(annotationProcessorDependency.id().groupId().get());
+    path.addChild(groupId);
+    Xpp3Dom artifactId = new Xpp3Dom("artifactId");
+    artifactId.setValue(annotationProcessorDependency.id().artifactId().get());
+    path.addChild(artifactId);
+    annotationProcessorDependency
+      .version()
+      .map(VersionSlug::mavenVariable)
+      .ifPresent(versionValue -> {
+        Xpp3Dom version = new Xpp3Dom("version");
+        version.setValue(versionValue);
+        path.addChild(version);
+      });
+    return path;
+  }
+
+  @Override
+  public void handle(RemoveJavaAnnotationProcessor command) {
+    Assert.notNull(COMMAND, command);
+
+    List<Plugin> managedPlugins = Optional.ofNullable(pomModel.getBuild())
+      .map(Build::getPluginManagement)
+      .map(PluginManagement::getPlugins)
+      .orElse(List.of());
+    List<Plugin> directPlugins = Optional.ofNullable(pomModel.getBuild()).map(Build::getPlugins).orElse(List.of());
+    Optional<Plugin> compilerPlugin = findCompilerPlugin(managedPlugins).or(() -> findCompilerPlugin(directPlugins));
+
+    Optional<Xpp3Dom> compilerConfiguration = compilerPlugin.map(Plugin::getConfiguration).map(Xpp3Dom.class::cast);
+
+    Optional<Xpp3Dom> annotationProcessorPaths = compilerConfiguration.map(configuration ->
+      configuration.getChild(ANNOTATION_PROCESSOR_PATHS_NODE)
+    );
+
+    List<Xpp3Dom> pathsToRemove = annotationProcessorPaths
+      .map(paths -> paths.getChildren("path"))
+      .stream()
+      .flatMap(Stream::of)
+      .filter(matchesAnnotationProcessorDependency(command.dependency()))
+      .toList();
+
+    annotationProcessorPaths.ifPresent(annotationProcessors -> {
+      pathsToRemove.forEach(annotationProcessors::removeChild);
+      if (annotationProcessors.getChildCount() == 0) {
+        compilerConfiguration.ifPresent(config -> config.removeChild(annotationProcessors));
+      }
+    });
+
+    writePom();
+  }
+
+  private Predicate<? super Xpp3Dom> matchesAnnotationProcessorDependency(DependencyId dependency) {
+    return annotationProcessorPath -> {
+      String groupId = annotationProcessorPath.getChild("groupId").getValue();
+      String artifactId = annotationProcessorPath.getChild("artifactId").getValue();
+      return dependency.groupId().get().equals(groupId) && dependency.artifactId().get().equals(artifactId);
+    };
   }
 
   @Override

--- a/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/maven/MavenProjectJavaDependenciesRepository.java
+++ b/src/main/java/com/seed4j/module/infrastructure/secondary/javadependency/maven/MavenProjectJavaDependenciesRepository.java
@@ -1,6 +1,8 @@
 package com.seed4j.module.infrastructure.secondary.javadependency.maven;
 
 import com.seed4j.module.domain.javabuild.VersionSlug;
+import com.seed4j.module.domain.javadependency.JavaAnnotationProcessorDependencies;
+import com.seed4j.module.domain.javadependency.JavaAnnotationProcessorDependency;
 import com.seed4j.module.domain.javadependency.JavaDependencies;
 import com.seed4j.module.domain.javadependency.JavaDependency;
 import com.seed4j.module.domain.javadependency.JavaDependencyVersion;
@@ -13,14 +15,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginContainer;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.springframework.stereotype.Repository;
 
@@ -43,8 +51,9 @@ public class MavenProjectJavaDependenciesRepository implements Seed4JProjectFold
 
       return ProjectJavaDependencies.builder()
         .versions(extractVersions(pomContent))
-        .dependenciesManagements(extractDependencyManagement(pomContent))
-        .dependencies(extractDependencies(pomContent));
+        .dependenciesManagement(extractDependencyManagement(pomContent))
+        .dependencies(extractDependencies(pomContent))
+        .annotationProcessingDependencies(extractAnnotationProcessingDependencies(pomContent));
     } catch (IOException | XmlPullParserException e) {
       throw GeneratorException.technicalError("Error reading pom file: " + e.getMessage(), e);
     }
@@ -86,6 +95,48 @@ public class MavenProjectJavaDependenciesRepository implements Seed4JProjectFold
     List<JavaDependency> mavenDependencies = pomContent.getDependencies().stream().map(toJavaDependency()).toList();
 
     return new JavaDependencies(mavenDependencies);
+  }
+
+  private JavaAnnotationProcessorDependencies extractAnnotationProcessingDependencies(Model pomContent) {
+    Optional<Plugin> compilerPlugin = Optional.ofNullable(pomContent.getBuild())
+      .map(Build::getPluginManagement)
+      .map(PluginContainer::getPlugins)
+      .flatMap(this::findCompilerPlugin)
+      .or(() -> Optional.ofNullable(pomContent.getBuild()).map(Build::getPlugins).flatMap(this::findCompilerPlugin));
+
+    List<JavaAnnotationProcessorDependency> dependencies = compilerPlugin
+      .map(Plugin::getConfiguration)
+      .filter(Xpp3Dom.class::isInstance)
+      .map(Xpp3Dom.class::cast)
+      .map(config -> config.getChild("annotationProcessorPaths"))
+      .map(annotationProcessorPaths -> annotationProcessorPaths.getChildren("path"))
+      .stream()
+      .flatMap(Arrays::stream)
+      .map(annotationProcessorPathToDependency())
+      .toList();
+
+    return new JavaAnnotationProcessorDependencies(dependencies);
+  }
+
+  private Function<? super Xpp3Dom, JavaAnnotationProcessorDependency> annotationProcessorPathToDependency() {
+    return domPath -> {
+      String groupId = domPath.getChild("groupId").getValue();
+      String artifactId = domPath.getChild("artifactId").getValue();
+      String version = domPath.getChild("version") != null ? domPath.getChild("version").getValue() : null;
+
+      return JavaAnnotationProcessorDependency.builder()
+        .groupId(groupId)
+        .artifactId(artifactId)
+        .versionSlug(VersionSlug.of(version).orElse(null))
+        .build();
+    };
+  }
+
+  private Optional<Plugin> findCompilerPlugin(List<Plugin> plugins) {
+    return plugins
+      .stream()
+      .filter(plugin -> plugin.getArtifactId().equals("maven-compiler-plugin"))
+      .findFirst();
   }
 
   private Function<Dependency, JavaDependency> toJavaDependency() {

--- a/src/main/java/com/seed4j/shared/slug/domain/Seed4JCoreModuleSlug.java
+++ b/src/main/java/com/seed4j/shared/slug/domain/Seed4JCoreModuleSlug.java
@@ -78,6 +78,7 @@ public enum Seed4JCoreModuleSlug implements Seed4JModuleSlugFactory {
   JOOQ_POSTGRESQL("jooq-postgresql", RANK_C),
   JPA_PAGINATION("jpa-pagination", RANK_A),
   JPA_MARIADB("jpa-mariadb", RANK_B),
+  JPA_METAMODEL_GENERATOR("jpa-metamodel-generator", RANK_A),
   JPA_MSSQL("jpa-mssql", RANK_C),
   JPA_MYSQL("jpa-mysql", RANK_A),
   JPA_POSTGRESQL("jpa-postgresql", RANK_S),

--- a/src/main/resources/generator/buildtool/gradle/build.gradle.kts.mustache
+++ b/src/main/resources/generator/buildtool/gradle/build.gradle.kts.mustache
@@ -32,6 +32,7 @@ val profiles = (project.findProperty("profiles") as String? ?: "")
 dependencies {
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies
   // seed4j-needle-gradle-test-dependencies
 }

--- a/src/main/resources/generator/buildtool/gradle/buildSrc/src/main/kotlin/profile.gradle.kts.mustache
+++ b/src/main/resources/generator/buildtool/gradle/buildSrc/src/main/kotlin/profile.gradle.kts.mustache
@@ -16,6 +16,7 @@ val libs = versionCatalogs.named("libs")
 dependencies {
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies
   // seed4j-needle-gradle-test-dependencies
 }

--- a/src/main/resources/generator/dependencies/build.gradle.kts
+++ b/src/main/resources/generator/dependencies/build.gradle.kts
@@ -27,6 +27,7 @@ version = "0.0.1-SNAPSHOT"
 dependencies {
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies
   // seed4j-needle-gradle-test-dependencies
 }

--- a/src/test/features/server/springboot/database/jpa/jpa.feature
+++ b/src/test/features/server/springboot/database/jpa/jpa.feature
@@ -107,3 +107,8 @@ Feature: JPA modules
       | baseName                  | STRING  | true      |
       | indentSize                | INTEGER | false     |
       | springConfigurationFormat | STRING  | false     |
+
+  Scenario: Should apply JPA metamodel generator module
+    When I apply "jpa-metamodel-generator" module to default project with maven file
+      | packageName | com.seed4j.growth |
+    Then I should have "hibernate-jpamodelgen" in "pom.xml"

--- a/src/test/features/server/springboot/database/jpa/jpa.feature
+++ b/src/test/features/server/springboot/database/jpa/jpa.feature
@@ -111,4 +111,10 @@ Feature: JPA modules
   Scenario: Should apply JPA metamodel generator module
     When I apply "jpa-metamodel-generator" module to default project with maven file
       | packageName | com.seed4j.growth |
-    Then I should have "hibernate-jpamodelgen" in "pom.xml"
+    Then I should have "hibernate-processor" in "pom.xml"
+
+  Scenario: Should apply JPA metamodel generator module with gradle
+    When I apply "jpa-metamodel-generator" module to default project with gradle build
+      | packageName | com.seed4j.growth |
+    Then I should have "annotationProcessor(libs.hibernate.processor)" in "build.gradle.kts"
+    Then I should have "[libraries.hibernate-processor]" in "gradle/libs.versions.toml"

--- a/src/test/java/com/seed4j/generator/server/javatool/jacoco/domain/JacocoModuleFactoryTest.java
+++ b/src/test/java/com/seed4j/generator/server/javatool/jacoco/domain/JacocoModuleFactoryTest.java
@@ -1,6 +1,8 @@
 package com.seed4j.generator.server.javatool.jacoco.domain;
 
-import static com.seed4j.module.infrastructure.secondary.Seed4JModulesAssertions.*;
+import static com.seed4j.module.infrastructure.secondary.Seed4JModulesAssertions.assertThatModuleWithFiles;
+import static com.seed4j.module.infrastructure.secondary.Seed4JModulesAssertions.gradleBuildFile;
+import static com.seed4j.module.infrastructure.secondary.Seed4JModulesAssertions.pomFile;
 
 import com.seed4j.TestFileUtils;
 import com.seed4j.UnitTest;
@@ -104,7 +106,9 @@ class JacocoModuleFactoryTest {
 
     @Test
     void shouldBuildJacocoWithMinCoverageCheckModule() {
-      Seed4JModuleProperties properties = Seed4JModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest()).build();
+      Seed4JModuleProperties properties = Seed4JModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest())
+        .basePackage("com.seed4j.example")
+        .build();
 
       Seed4JModule module = factory.buildJacocoWithMinCoverageCheckModule(properties);
 
@@ -119,6 +123,12 @@ class JacocoModuleFactoryTest {
                         </goals>
                         <configuration>
                           <dataFile>target/jacoco/allTest.exec</dataFile>
+                          <includes>
+                            <include>com/seed4j/example/**</include>
+                          </includes>
+                          <excludes>
+                            <exclude>com/seed4j/example/**/infrastructure/secondary/**/*Entity_.class</exclude>
+                          </excludes>
                           <rules>
                             <rule>
                               <element>CLASS</element>
@@ -192,7 +202,9 @@ class JacocoModuleFactoryTest {
 
   @Test
   void shouldBuildJacocoWithMinCoverageCheckModule() {
-    Seed4JModuleProperties properties = Seed4JModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest()).build();
+    Seed4JModuleProperties properties = Seed4JModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest())
+      .basePackage("com.seed4j.example")
+      .build();
 
     Seed4JModule module = factory.buildJacocoWithMinCoverageCheckModule(properties);
 
@@ -216,11 +228,23 @@ class JacocoModuleFactoryTest {
             xml.required.set(true)
             html.required.set(true)
           }
+          classDirectories.setFrom(
+            fileTree(layout.buildDirectory.dir("classes")) {
+              include("com/seed4j/example/**")
+              exclude("com/seed4j/example/**/infrastructure/secondary/**/*Entity_*")
+            }
+          )
           executionData.setFrom(fileTree(layout.buildDirectory).include("**/jacoco/test.exec", "**/jacoco/integrationTest.exec"))
         }
 
         tasks.jacocoTestCoverageVerification {
           dependsOn("jacocoTestReport")
+          classDirectories.setFrom(
+            fileTree(layout.buildDirectory.dir("classes")) {
+              include("com/seed4j/example/**")
+              exclude("com/seed4j/example/**/infrastructure/secondary/**/*Entity_*")
+            }
+          )
           violationRules {
 
               rule {

--- a/src/test/java/com/seed4j/generator/server/springboot/database/jpa/domain/JpaModuleFactoryTest.java
+++ b/src/test/java/com/seed4j/generator/server/springboot/database/jpa/domain/JpaModuleFactoryTest.java
@@ -1,6 +1,7 @@
 package com.seed4j.generator.server.springboot.database.jpa.domain;
 
 import static com.seed4j.module.infrastructure.secondary.Seed4JModulesAssertions.assertThatModuleWithFiles;
+import static com.seed4j.module.infrastructure.secondary.Seed4JModulesAssertions.fileFromClasspath;
 import static com.seed4j.module.infrastructure.secondary.Seed4JModulesAssertions.pomFile;
 
 import com.seed4j.TestFileUtils;
@@ -230,6 +231,27 @@ class JpaModuleFactoryTest {
                 query:
                   fail_on_pagination_over_collection_fetch: true
                   in_clause_parameter_padding: true
+        """
+      );
+  }
+
+  @Test
+  void shouldBuildMetaModelGeneratorModule() {
+    Seed4JModuleProperties properties = Seed4JModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest()).build();
+
+    Seed4JModule module = factory.buildMetaModelGenerator(properties);
+
+    assertThatModuleWithFiles(module, fileFromClasspath("projects/init-maven/pom.xml", "pom.xml"))
+      .hasFile("pom.xml")
+      .containing(
+        // language=xml
+        """
+                  <annotationProcessorPaths>
+                    <path>
+                      <groupId>org.hibernate.orm</groupId>
+                      <artifactId>hibernate-processor</artifactId>
+                    </path>
+                  </annotationProcessorPaths>
         """
       );
   }

--- a/src/test/java/com/seed4j/module/domain/Seed4JModulesFixture.java
+++ b/src/test/java/com/seed4j/module/domain/Seed4JModulesFixture.java
@@ -16,6 +16,7 @@ import static com.seed4j.module.domain.Seed4JModule.gradleCommunityPlugin;
 import static com.seed4j.module.domain.Seed4JModule.gradleCorePlugin;
 import static com.seed4j.module.domain.Seed4JModule.gradleProfilePlugin;
 import static com.seed4j.module.domain.Seed4JModule.groupId;
+import static com.seed4j.module.domain.Seed4JModule.javaAnnotationProcessorDependency;
 import static com.seed4j.module.domain.Seed4JModule.javaDependency;
 import static com.seed4j.module.domain.Seed4JModule.lineBeforeRegex;
 import static com.seed4j.module.domain.Seed4JModule.lineBeforeText;
@@ -53,6 +54,7 @@ import com.seed4j.module.domain.javabuild.command.RemoveDirectJavaDependency;
 import com.seed4j.module.domain.javabuild.command.SetVersion;
 import com.seed4j.module.domain.javabuildprofile.BuildProfileId;
 import com.seed4j.module.domain.javadependency.DependencyId;
+import com.seed4j.module.domain.javadependency.JavaAnnotationProcessorDependency;
 import com.seed4j.module.domain.javadependency.JavaDependenciesVersions;
 import com.seed4j.module.domain.javadependency.JavaDependency;
 import com.seed4j.module.domain.javadependency.JavaDependency.JavaDependencyOptionalValueBuilder;
@@ -146,6 +148,10 @@ public final class Seed4JModulesFixture {
       .addDependencyManagement(springBootDependencyManagement())
       .addDependencyManagement(springBootDefaultTypeDependencyManagement())
       .removeDependencyManagement(dependencyId("org.springdoc", "springdoc-openapi-ui"))
+      .and()
+    .javaCompiler()
+      .addAnnotationProcessor(hibernateAnnotationProcessor())
+      .removeAnnotationProcessor(googleAutoServiceAnnotationProcessor().id())
       .and()
     .mavenPlugins()
       .pluginManagement(mavenEnforcerPluginManagement())
@@ -325,6 +331,18 @@ public final class Seed4JModulesFixture {
       .versionSlug("json-web-token")
       .addExclusion(DependencyId.of(new GroupId("com.fasterxml.jackson.core"), new ArtifactId("jackson-databind")))
       .build();
+  }
+
+  public static JavaAnnotationProcessorDependency googleAutoServiceAnnotationProcessor() {
+    return javaAnnotationProcessorDependency()
+      .groupId("com.google.auto.service")
+      .artifactId("auto-service")
+      .versionSlug("google-auto-service")
+      .build();
+  }
+
+  public static JavaAnnotationProcessorDependency hibernateAnnotationProcessor() {
+    return javaAnnotationProcessorDependency().groupId("org.hibernate.orm").artifactId("hibernate-processor").build();
   }
 
   public static JavaBuildCommands javaDependenciesCommands() {

--- a/src/test/java/com/seed4j/module/domain/javadependency/DirectJavaDependencyTest.java
+++ b/src/test/java/com/seed4j/module/domain/javadependency/DirectJavaDependencyTest.java
@@ -47,8 +47,9 @@ class DirectJavaDependencyTest {
   void shouldNotUpdateExistingDefaultVersionDependency() {
     ProjectJavaDependencies projectJavaDependencies = ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(JavaDependencies.EMPTY)
-      .dependencies(new JavaDependencies(List.of(defaultVersionDependency())));
+      .dependenciesManagement(JavaDependencies.EMPTY)
+      .dependencies(new JavaDependencies(List.of(defaultVersionDependency())))
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
 
     JavaBuildCommands commands = changes().projectDependencies(projectJavaDependencies).build();
 
@@ -59,8 +60,9 @@ class DirectJavaDependencyTest {
   void shouldUpgradeDependencyOptionality() {
     ProjectJavaDependencies projectJavaDependencies = ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(JavaDependencies.EMPTY)
-      .dependencies(new JavaDependencies(List.of(optionalSpringBootDependency())));
+      .dependenciesManagement(JavaDependencies.EMPTY)
+      .dependencies(new JavaDependencies(List.of(optionalSpringBootDependency())))
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
 
     JavaBuildCommands commands = changes().projectDependencies(projectJavaDependencies).build();
 
@@ -74,8 +76,9 @@ class DirectJavaDependencyTest {
   void shouldNotDowngradeDependencyOptionality() {
     ProjectJavaDependencies projectJavaDependencies = ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(JavaDependencies.EMPTY)
-      .dependencies(new JavaDependencies(List.of(defaultVersionDependency())));
+      .dependenciesManagement(JavaDependencies.EMPTY)
+      .dependencies(new JavaDependencies(List.of(defaultVersionDependency())))
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
 
     JavaBuildCommands commands = changes().dependency(optionalSpringBootDependency()).projectDependencies(projectJavaDependencies).build();
 
@@ -148,8 +151,9 @@ class DirectJavaDependencyTest {
   private ProjectJavaDependencies projectDependenciesWithoutJunitVersion() {
     return ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(projectDependenciesManagement())
-      .dependencies(noJunitVersionInCurrentProject());
+      .dependenciesManagement(projectDependenciesManagement())
+      .dependencies(noJunitVersionInCurrentProject())
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
   }
 
   private JavaDependencies noJunitVersionInCurrentProject() {
@@ -172,8 +176,9 @@ class DirectJavaDependencyTest {
   private ProjectJavaDependencies projectJavaDependencies() {
     return ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(JavaDependencies.EMPTY)
-      .dependencies(projectDependencies());
+      .dependenciesManagement(JavaDependencies.EMPTY)
+      .dependencies(projectDependencies())
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
   }
 
   private ProjectJavaDependenciesVersions projectVersions() {

--- a/src/test/java/com/seed4j/module/domain/javadependency/JavaAnnotationProcessorDependenciesTest.java
+++ b/src/test/java/com/seed4j/module/domain/javadependency/JavaAnnotationProcessorDependenciesTest.java
@@ -1,0 +1,52 @@
+package com.seed4j.module.domain.javadependency;
+
+import static com.seed4j.module.domain.Seed4JModulesFixture.googleAutoServiceAnnotationProcessor;
+import static com.seed4j.module.domain.Seed4JModulesFixture.hibernateAnnotationProcessor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.seed4j.UnitTest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class JavaAnnotationProcessorDependenciesTest {
+
+  @Test
+  void shouldBeEmpty() {
+    assertThat(JavaAnnotationProcessorDependencies.EMPTY.get(hibernateAnnotationProcessor().id())).isEmpty();
+  }
+
+  @Test
+  void shouldGetExistingDependency() {
+    JavaAnnotationProcessorDependencies deps = new JavaAnnotationProcessorDependencies(List.of(hibernateAnnotationProcessor()));
+
+    assertThat(deps.get(hibernateAnnotationProcessor().id())).contains(hibernateAnnotationProcessor());
+  }
+
+  @Test
+  void shouldReturnEmptyForMissingDependency() {
+    JavaAnnotationProcessorDependencies deps = new JavaAnnotationProcessorDependencies(List.of(hibernateAnnotationProcessor()));
+
+    assertThat(deps.get(googleAutoServiceAnnotationProcessor().id())).isEmpty();
+  }
+
+  @Test
+  void shouldMergeDisjointDependencies() {
+    JavaAnnotationProcessorDependencies first = new JavaAnnotationProcessorDependencies(List.of(hibernateAnnotationProcessor()));
+    JavaAnnotationProcessorDependencies second = new JavaAnnotationProcessorDependencies(List.of(googleAutoServiceAnnotationProcessor()));
+
+    JavaAnnotationProcessorDependencies merged = first.merge(second);
+
+    assertThat(merged.get(hibernateAnnotationProcessor().id())).contains(hibernateAnnotationProcessor());
+    assertThat(merged.get(googleAutoServiceAnnotationProcessor().id())).contains(googleAutoServiceAnnotationProcessor());
+  }
+
+  @Test
+  void shouldMergeWithEmptyOther() {
+    JavaAnnotationProcessorDependencies deps = new JavaAnnotationProcessorDependencies(List.of(hibernateAnnotationProcessor()));
+
+    JavaAnnotationProcessorDependencies merged = deps.merge(JavaAnnotationProcessorDependencies.EMPTY);
+
+    assertThat(merged.get(hibernateAnnotationProcessor().id())).contains(hibernateAnnotationProcessor());
+  }
+}

--- a/src/test/java/com/seed4j/module/domain/javadependency/JavaAnnotationProcessorDependencyTest.java
+++ b/src/test/java/com/seed4j/module/domain/javadependency/JavaAnnotationProcessorDependencyTest.java
@@ -1,0 +1,175 @@
+package com.seed4j.module.domain.javadependency;
+
+import static com.seed4j.module.domain.Seed4JModule.javaAnnotationProcessorDependency;
+import static com.seed4j.module.domain.Seed4JModulesFixture.currentJavaDependenciesVersion;
+import static com.seed4j.module.domain.Seed4JModulesFixture.hibernateAnnotationProcessor;
+import static com.seed4j.module.domain.Seed4JModulesFixture.springBootVersion;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.seed4j.UnitTest;
+import com.seed4j.module.domain.javabuild.ArtifactId;
+import com.seed4j.module.domain.javabuild.GroupId;
+import com.seed4j.module.domain.javabuild.command.AddJavaAnnotationProcessor;
+import com.seed4j.module.domain.javabuild.command.JavaBuildCommands;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaAnnotationProcessor;
+import com.seed4j.module.domain.javabuild.command.SetVersion;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class JavaAnnotationProcessorDependencyTest {
+
+  @Test
+  void shouldBuildWithStringClassifier() {
+    JavaAnnotationProcessorDependency dependency = javaAnnotationProcessorDependency()
+      .groupId("org.hibernate.orm")
+      .artifactId("hibernate-processor")
+      .classifier("tests")
+      .build();
+
+    assertThat(dependency.classifier()).contains(new JavaDependencyClassifier("tests"));
+  }
+
+  @Test
+  void shouldBuildWithExclusion() {
+    JavaAnnotationProcessorDependency dependency = javaAnnotationProcessorDependency()
+      .groupId("org.hibernate.orm")
+      .artifactId("hibernate-processor")
+      .addExclusion(new GroupId("com.example"), new ArtifactId("excluded-lib"))
+      .build();
+
+    assertThat(dependency.exclusions()).containsExactly(DependencyId.of(new GroupId("com.example"), new ArtifactId("excluded-lib")));
+  }
+
+  @Test
+  void shouldAddUnknownAnnotationProcessorDependency() {
+    JavaBuildCommands commands = changes().build();
+
+    assertThat(commands.get()).containsExactly(new AddJavaAnnotationProcessor(hibernateAnnotationProcessor()));
+  }
+
+  @Test
+  void shouldAddUnknownAnnotationProcessorDependencyWithVersion() {
+    JavaAnnotationProcessorDependency withVersion = javaAnnotationProcessorDependency()
+      .groupId("org.hibernate.orm")
+      .artifactId("hibernate-processor")
+      .versionSlug("spring-boot")
+      .build();
+
+    JavaBuildCommands commands = changes().dependency(withVersion).build();
+
+    assertThat(commands.get()).containsExactly(new AddJavaAnnotationProcessor(withVersion), new SetVersion(springBootVersion()));
+  }
+
+  @Test
+  void shouldNotUpdateExistingAnnotationProcessorDependency() {
+    JavaAnnotationProcessorDependency existing = hibernateAnnotationProcessor();
+
+    JavaBuildCommands commands = changes().projectDependencies(projectWithAnnotationProcessor(existing)).build();
+
+    assertThat(commands.get()).isEmpty();
+  }
+
+  @Test
+  void shouldUpdateAnnotationProcessorDependencyVersion() {
+    JavaAnnotationProcessorDependency withVersion = javaAnnotationProcessorDependency()
+      .groupId("org.hibernate.orm")
+      .artifactId("hibernate-processor")
+      .versionSlug("spring-boot")
+      .build();
+    JavaDependencyVersion updatedVersion = new JavaDependencyVersion("spring-boot", "2.0.0");
+    JavaDependenciesVersions currentVersions = new JavaDependenciesVersions(List.of(updatedVersion));
+
+    JavaAnnotationProcessorDependency existingWithVersion = javaAnnotationProcessorDependency()
+      .groupId("org.hibernate.orm")
+      .artifactId("hibernate-processor")
+      .versionSlug("spring-boot")
+      .build();
+    JavaBuildCommands commands = changes()
+      .dependency(withVersion)
+      .currentVersions(currentVersions)
+      .projectDependencies(projectWithAnnotationProcessor(existingWithVersion))
+      .build();
+
+    assertThat(commands.get()).containsExactly(new SetVersion(updatedVersion));
+  }
+
+  @Test
+  void shouldKeepVersionFromProject() {
+    JavaAnnotationProcessorDependency withoutVersion = hibernateAnnotationProcessor();
+
+    JavaAnnotationProcessorDependency existingWithVersion = javaAnnotationProcessorDependency()
+      .groupId("org.hibernate.orm")
+      .artifactId("hibernate-processor")
+      .versionSlug("spring-boot")
+      .build();
+    JavaBuildCommands commands = changes()
+      .dependency(withoutVersion)
+      .projectDependencies(projectWithAnnotationProcessor(existingWithVersion))
+      .build();
+
+    assertThat(commands.get()).isEmpty();
+  }
+
+  @Test
+  void shouldUpdateAnnotationProcessorWhenVersionChanges() {
+    JavaAnnotationProcessorDependency withNewVersion = javaAnnotationProcessorDependency()
+      .groupId("org.hibernate.orm")
+      .artifactId("hibernate-processor")
+      .versionSlug("spring-boot")
+      .build();
+
+    JavaAnnotationProcessorDependency existingWithoutVersion = hibernateAnnotationProcessor();
+    JavaBuildCommands commands = changes()
+      .dependency(withNewVersion)
+      .projectDependencies(projectWithAnnotationProcessor(existingWithoutVersion))
+      .build();
+
+    assertThat(commands.get()).containsExactly(
+      new RemoveJavaAnnotationProcessor(hibernateAnnotationProcessor().id()),
+      new AddJavaAnnotationProcessor(withNewVersion),
+      new SetVersion(springBootVersion())
+    );
+  }
+
+  private ProjectJavaDependencies projectWithAnnotationProcessor(JavaAnnotationProcessorDependency dep) {
+    return ProjectJavaDependencies.builder()
+      .versions(new ProjectJavaDependenciesVersions(List.of(springBootVersion())))
+      .dependenciesManagement(JavaDependencies.EMPTY)
+      .dependencies(JavaDependencies.EMPTY)
+      .annotationProcessingDependencies(new JavaAnnotationProcessorDependencies(List.of(dep)));
+  }
+
+  private static ChangesBuilder changes() {
+    return new ChangesBuilder();
+  }
+
+  private static final class ChangesBuilder {
+
+    private JavaAnnotationProcessorDependency dependency = hibernateAnnotationProcessor();
+    private JavaDependenciesVersions currentVersions = currentJavaDependenciesVersion();
+    private ProjectJavaDependencies projectDependencies = ProjectJavaDependencies.EMPTY;
+
+    private ChangesBuilder dependency(JavaAnnotationProcessorDependency dependency) {
+      this.dependency = dependency;
+
+      return this;
+    }
+
+    private ChangesBuilder currentVersions(JavaDependenciesVersions currentVersions) {
+      this.currentVersions = currentVersions;
+
+      return this;
+    }
+
+    private ChangesBuilder projectDependencies(ProjectJavaDependencies projectDependencies) {
+      this.projectDependencies = projectDependencies;
+
+      return this;
+    }
+
+    private JavaBuildCommands build() {
+      return dependency.changeCommands(currentVersions, projectDependencies);
+    }
+  }
+}

--- a/src/test/java/com/seed4j/module/domain/javadependency/JavaDependencyManagementTest.java
+++ b/src/test/java/com/seed4j/module/domain/javadependency/JavaDependencyManagementTest.java
@@ -51,8 +51,9 @@ class JavaDependencyManagementTest {
   void shouldNotUpdateExistingDefaultVersionDependency() {
     ProjectJavaDependencies projectJavaDependencies = ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(new JavaDependencies(List.of(defaultVersionDependency())))
-      .dependencies(JavaDependencies.EMPTY);
+      .dependenciesManagement(new JavaDependencies(List.of(defaultVersionDependency())))
+      .dependencies(JavaDependencies.EMPTY)
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
 
     JavaBuildCommands commands = changes().projectDependencies(projectJavaDependencies).build();
 
@@ -63,8 +64,9 @@ class JavaDependencyManagementTest {
   void shouldUpgradeDependencyOptionality() {
     ProjectJavaDependencies projectJavaDependencies = ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(new JavaDependencies(List.of(optionalSpringBootDependency())))
-      .dependencies(JavaDependencies.EMPTY);
+      .dependenciesManagement(new JavaDependencies(List.of(optionalSpringBootDependency())))
+      .dependencies(JavaDependencies.EMPTY)
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
 
     JavaBuildCommands commands = changes().projectDependencies(projectJavaDependencies).build();
 
@@ -78,8 +80,9 @@ class JavaDependencyManagementTest {
   void shouldNotDowngradeDependencyOptionality() {
     ProjectJavaDependencies projectJavaDependencies = ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(new JavaDependencies(List.of(defaultVersionDependency())))
-      .dependencies(JavaDependencies.EMPTY);
+      .dependenciesManagement(new JavaDependencies(List.of(defaultVersionDependency())))
+      .dependencies(JavaDependencies.EMPTY)
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
 
     JavaBuildCommands commands = changes().dependency(optionalSpringBootDependency()).projectDependencies(projectJavaDependencies).build();
 
@@ -152,8 +155,9 @@ class JavaDependencyManagementTest {
   private ProjectJavaDependencies projectDependenciesWithoutJunitVersion() {
     return ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(noJunitVersionInCurrentProject())
-      .dependencies(JavaDependencies.EMPTY);
+      .dependenciesManagement(noJunitVersionInCurrentProject())
+      .dependencies(JavaDependencies.EMPTY)
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
   }
 
   private JavaDependencies noJunitVersionInCurrentProject() {
@@ -173,8 +177,9 @@ class JavaDependencyManagementTest {
   void shouldNotUpdateDependencyWithSameType() {
     ProjectJavaDependencies projectDependencies = ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(new JavaDependencies(List.of(springBootDependencyManagement())))
-      .dependencies(JavaDependencies.EMPTY);
+      .dependenciesManagement(new JavaDependencies(List.of(springBootDependencyManagement())))
+      .dependencies(JavaDependencies.EMPTY)
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
 
     JavaBuildCommands changes = changes().dependency(springBootDependencyManagement()).projectDependencies(projectDependencies).build();
 
@@ -187,8 +192,9 @@ class JavaDependencyManagementTest {
 
     ProjectJavaDependencies projectDependencies = ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(new JavaDependencies(List.of(noTypeDependencyManagement)))
-      .dependencies(JavaDependencies.EMPTY);
+      .dependenciesManagement(new JavaDependencies(List.of(noTypeDependencyManagement)))
+      .dependencies(JavaDependencies.EMPTY)
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
 
     JavaBuildCommands changes = changes().dependency(springBootDependencyManagement()).projectDependencies(projectDependencies).build();
 
@@ -204,8 +210,9 @@ class JavaDependencyManagementTest {
 
     ProjectJavaDependencies projectDependencies = ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(new JavaDependencies(List.of(differentClassifier)))
-      .dependencies(JavaDependencies.EMPTY);
+      .dependenciesManagement(new JavaDependencies(List.of(differentClassifier)))
+      .dependencies(JavaDependencies.EMPTY)
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
 
     JavaBuildCommands changes = changes().dependency(optionalTestDependency()).projectDependencies(projectDependencies).build();
 
@@ -222,8 +229,9 @@ class JavaDependencyManagementTest {
   private ProjectJavaDependencies projectJavaDependencies() {
     return ProjectJavaDependencies.builder()
       .versions(projectVersions())
-      .dependenciesManagements(projectDependenciesManagement())
-      .dependencies(JavaDependencies.EMPTY);
+      .dependenciesManagement(projectDependenciesManagement())
+      .dependencies(JavaDependencies.EMPTY)
+      .annotationProcessingDependencies(JavaAnnotationProcessorDependencies.EMPTY);
   }
 
   private ProjectJavaDependenciesVersions projectVersions() {

--- a/src/test/java/com/seed4j/module/domain/javadependency/Seed4JModuleJavaCompilerTest.java
+++ b/src/test/java/com/seed4j/module/domain/javadependency/Seed4JModuleJavaCompilerTest.java
@@ -1,0 +1,45 @@
+package com.seed4j.module.domain.javadependency;
+
+import static com.seed4j.module.domain.Seed4JModulesFixture.currentJavaDependenciesVersion;
+import static com.seed4j.module.domain.Seed4JModulesFixture.googleAutoServiceAnnotationProcessor;
+import static com.seed4j.module.domain.Seed4JModulesFixture.hibernateAnnotationProcessor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.seed4j.UnitTest;
+import com.seed4j.module.domain.javabuild.command.AddJavaAnnotationProcessor;
+import com.seed4j.module.domain.javabuild.command.JavaBuildCommands;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaAnnotationProcessor;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class Seed4JModuleJavaCompilerTest {
+
+  @Test
+  void shouldBuildEmptyChangesWhenNoAnnotationProcessors() {
+    JavaBuildCommands commands = Seed4JModuleJavaCompiler.builder(new Object())
+      .build()
+      .buildChanges(currentJavaDependenciesVersion(), ProjectJavaDependencies.EMPTY);
+
+    assertThat(commands.get()).isEmpty();
+  }
+
+  @Test
+  void shouldBuildAddAnnotationProcessorCommand() {
+    JavaBuildCommands commands = Seed4JModuleJavaCompiler.builder(new Object())
+      .addAnnotationProcessor(hibernateAnnotationProcessor())
+      .build()
+      .buildChanges(currentJavaDependenciesVersion(), ProjectJavaDependencies.EMPTY);
+
+    assertThat(commands.get()).containsExactly(new AddJavaAnnotationProcessor(hibernateAnnotationProcessor()));
+  }
+
+  @Test
+  void shouldBuildRemoveAnnotationProcessorCommand() {
+    JavaBuildCommands commands = Seed4JModuleJavaCompiler.builder(new Object())
+      .removeAnnotationProcessor(googleAutoServiceAnnotationProcessor().id())
+      .build()
+      .buildChanges(currentJavaDependenciesVersion(), ProjectJavaDependencies.EMPTY);
+
+    assertThat(commands.get()).containsExactly(new RemoveJavaAnnotationProcessor(googleAutoServiceAnnotationProcessor().id()));
+  }
+}

--- a/src/test/java/com/seed4j/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandlerTest.java
+++ b/src/test/java/com/seed4j/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandlerTest.java
@@ -7,6 +7,7 @@ import static com.seed4j.module.domain.Seed4JModule.artifactId;
 import static com.seed4j.module.domain.Seed4JModule.buildProfileId;
 import static com.seed4j.module.domain.Seed4JModule.gradleCommunityPlugin;
 import static com.seed4j.module.domain.Seed4JModule.groupId;
+import static com.seed4j.module.domain.Seed4JModule.javaAnnotationProcessorDependency;
 import static com.seed4j.module.domain.Seed4JModule.javaDependency;
 import static com.seed4j.module.domain.Seed4JModulesFixture.checkstyleGradlePlugin;
 import static com.seed4j.module.domain.Seed4JModulesFixture.checkstyleGradleProfilePlugin;
@@ -45,16 +46,19 @@ import com.seed4j.module.domain.javabuild.command.AddDirectMavenPlugin;
 import com.seed4j.module.domain.javabuild.command.AddGradleConfiguration;
 import com.seed4j.module.domain.javabuild.command.AddGradlePlugin;
 import com.seed4j.module.domain.javabuild.command.AddGradleTasksTestInstruction;
+import com.seed4j.module.domain.javabuild.command.AddJavaAnnotationProcessor;
 import com.seed4j.module.domain.javabuild.command.AddJavaBuildProfile;
 import com.seed4j.module.domain.javabuild.command.AddJavaDependencyManagement;
 import com.seed4j.module.domain.javabuild.command.AddMavenBuildExtension;
 import com.seed4j.module.domain.javabuild.command.AddMavenPluginManagement;
 import com.seed4j.module.domain.javabuild.command.RemoveDirectJavaDependency;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaAnnotationProcessor;
 import com.seed4j.module.domain.javabuild.command.RemoveJavaDependencyManagement;
 import com.seed4j.module.domain.javabuild.command.SetBuildProperty;
 import com.seed4j.module.domain.javabuild.command.SetVersion;
 import com.seed4j.module.domain.javabuildprofile.BuildProfileActivation;
 import com.seed4j.module.domain.javabuildprofile.BuildProfileId;
+import com.seed4j.module.domain.javadependency.JavaAnnotationProcessorDependency;
 import com.seed4j.module.domain.javadependency.JavaDependency;
 import com.seed4j.module.domain.javadependency.JavaDependencyScope;
 import com.seed4j.module.domain.javadependency.JavaDependencyType;
@@ -534,6 +538,74 @@ class GradleCommandHandlerTest {
   }
 
   @Nested
+  class HandleAddAnnotationProcessor {
+
+    private final Seed4JProjectFolder emptyGradleProjectFolder = projectFrom("src/test/resources/projects/empty-gradle");
+
+    @Test
+    void shouldAddAnnotationProcessorDependencyInBuildGradleFile() {
+      JavaAnnotationProcessorDependency dependency = javaAnnotationProcessorDependency()
+        .groupId("com.google.auto.service")
+        .artifactId("auto-service")
+        .versionSlug("auto-service")
+        .build();
+      new GradleCommandHandler(Indentation.DEFAULT, emptyGradleProjectFolder, emptyModuleContext(), files, fileReplacer).handle(
+        new AddJavaAnnotationProcessor(dependency)
+      );
+
+      assertThat(buildGradleContent(emptyGradleProjectFolder)).contains("annotationProcessor(libs.auto.service)");
+      assertThat(versionCatalogContent(emptyGradleProjectFolder)).contains(
+        """
+        [libraries.auto-service]
+        \t\tname = "auto-service"
+        \t\tgroup = "com.google.auto.service"
+        """
+      );
+    }
+
+    @Test
+    void shouldAddAnnotationProcessorDependencyWithExclusionsInBuildGradleFile() {
+      JavaAnnotationProcessorDependency dependency = javaAnnotationProcessorDependency()
+        .groupId("com.google.auto.service")
+        .artifactId("auto-service")
+        .addExclusion(groupId("com.google.guava"), artifactId("guava"))
+        .build();
+      new GradleCommandHandler(Indentation.DEFAULT, emptyGradleProjectFolder, emptyModuleContext(), files, fileReplacer).handle(
+        new AddJavaAnnotationProcessor(dependency)
+      );
+
+      assertThat(buildGradleContent(emptyGradleProjectFolder)).contains(
+        """
+          annotationProcessor(libs.auto.service) {
+            exclude(group = "com.google.guava", module = "guava")
+          }
+        """
+      );
+    }
+
+    @Test
+    void shouldNotDuplicateAnnotationProcessorDependencyInBuildGradleFile() {
+      JavaAnnotationProcessorDependency dependency = javaAnnotationProcessorDependency()
+        .groupId("com.google.auto.service")
+        .artifactId("auto-service")
+        .versionSlug("auto-service")
+        .build();
+      GradleCommandHandler gradleCommandHandler = new GradleCommandHandler(
+        Indentation.DEFAULT,
+        emptyGradleProjectFolder,
+        emptyModuleContext(),
+        files,
+        fileReplacer
+      );
+      AddJavaAnnotationProcessor command = new AddJavaAnnotationProcessor(dependency);
+      gradleCommandHandler.handle(command);
+      gradleCommandHandler.handle(command);
+
+      assertThat(buildGradleContent(emptyGradleProjectFolder)).containsOnlyOnce("annotationProcessor(libs.auto.service)");
+    }
+  }
+
+  @Nested
   class HandleAddDirectJavaDependency {
 
     private final Seed4JProjectFolder emptyGradleProjectFolder = projectFrom("src/test/resources/projects/empty-gradle");
@@ -744,6 +816,7 @@ class GradleCommandHandlerTest {
           // seed4j-needle-gradle-implementation-dependencies
           compileOnly(libs.junit.jupiter.engine)
           // seed4j-needle-gradle-compile-dependencies
+          // seed4j-needle-gradle-annotation-processors
           runtimeOnly(libs.spring.boot.starter.webmvc)
           // seed4j-needle-gradle-runtime-dependencies
           testImplementation(libs.junit.jupiter.engine)
@@ -771,6 +844,59 @@ class GradleCommandHandlerTest {
         runtimeOnly(libs.findLibrary("spring.boot.starter.webmvc").get())\
         """
       );
+    }
+  }
+
+  @Nested
+  class HandleRemoveAnnotationProcessor {
+
+    private final Seed4JProjectFolder emptyGradleProjectFolder = projectFrom("src/test/resources/projects/empty-gradle");
+
+    @Test
+    void shouldRemoveEntryInLibrariesSection() {
+      GradleCommandHandler gradleCommandHandler = new GradleCommandHandler(
+        Indentation.DEFAULT,
+        emptyGradleProjectFolder,
+        emptyModuleContext(),
+        files,
+        fileReplacer
+      );
+      gradleCommandHandler.handle(
+        new AddJavaAnnotationProcessor(
+          javaAnnotationProcessorDependency().groupId("org.springframework.boot").artifactId("spring-boot-starter").build()
+        )
+      );
+
+      gradleCommandHandler.handle(new RemoveJavaAnnotationProcessor(defaultVersionDependency().id()));
+
+      assertThat(versionCatalogContent(emptyGradleProjectFolder))
+        .doesNotContain("[libraries.spring-boot-starter]")
+        .doesNotContain(
+          """
+          \t\tname = "spring-boot-starter"
+          \t\tgroup = "org.springframework.boot"
+          """
+        );
+    }
+
+    @Test
+    void shouldRemoveDependencyInBuildGradleFile() {
+      GradleCommandHandler gradleCommandHandler = new GradleCommandHandler(
+        Indentation.DEFAULT,
+        emptyGradleProjectFolder,
+        emptyModuleContext(),
+        files,
+        fileReplacer
+      );
+      gradleCommandHandler.handle(
+        new AddJavaAnnotationProcessor(
+          javaAnnotationProcessorDependency().groupId("org.springframework.boot").artifactId("spring-boot-starter").build()
+        )
+      );
+
+      gradleCommandHandler.handle(new RemoveJavaAnnotationProcessor(defaultVersionDependency().id()));
+
+      assertThat(buildGradleContent(emptyGradleProjectFolder)).doesNotContain("annotationProcessor(libs.spring.boot.starter)");
     }
   }
 

--- a/src/test/java/com/seed4j/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
+++ b/src/test/java/com/seed4j/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
@@ -5,10 +5,13 @@ import static com.seed4j.TestFileUtils.tmpDirForTest;
 import static com.seed4j.module.domain.Seed4JModule.artifactId;
 import static com.seed4j.module.domain.Seed4JModule.dependencyId;
 import static com.seed4j.module.domain.Seed4JModule.groupId;
+import static com.seed4j.module.domain.Seed4JModule.javaAnnotationProcessorDependency;
 import static com.seed4j.module.domain.Seed4JModule.mavenPlugin;
 import static com.seed4j.module.domain.Seed4JModulesFixture.asciidoctorPlugin;
 import static com.seed4j.module.domain.Seed4JModulesFixture.checkstyleGradlePlugin;
 import static com.seed4j.module.domain.Seed4JModulesFixture.defaultVersionDependency;
+import static com.seed4j.module.domain.Seed4JModulesFixture.googleAutoServiceAnnotationProcessor;
+import static com.seed4j.module.domain.Seed4JModulesFixture.hibernateAnnotationProcessor;
 import static com.seed4j.module.domain.Seed4JModulesFixture.jsonWebTokenDependencyId;
 import static com.seed4j.module.domain.Seed4JModulesFixture.localBuildProfile;
 import static com.seed4j.module.domain.Seed4JModulesFixture.mavenBuildExtensionWithSlug;
@@ -33,11 +36,13 @@ import com.seed4j.module.domain.buildproperties.PropertyValue;
 import com.seed4j.module.domain.javabuild.command.AddDirectJavaDependency;
 import com.seed4j.module.domain.javabuild.command.AddDirectMavenPlugin;
 import com.seed4j.module.domain.javabuild.command.AddGradlePlugin;
+import com.seed4j.module.domain.javabuild.command.AddJavaAnnotationProcessor;
 import com.seed4j.module.domain.javabuild.command.AddJavaBuildProfile;
 import com.seed4j.module.domain.javabuild.command.AddJavaDependencyManagement;
 import com.seed4j.module.domain.javabuild.command.AddMavenBuildExtension;
 import com.seed4j.module.domain.javabuild.command.AddMavenPluginManagement;
 import com.seed4j.module.domain.javabuild.command.RemoveDirectJavaDependency;
+import com.seed4j.module.domain.javabuild.command.RemoveJavaAnnotationProcessor;
 import com.seed4j.module.domain.javabuild.command.RemoveJavaDependencyManagement;
 import com.seed4j.module.domain.javabuild.command.SetBuildProperty;
 import com.seed4j.module.domain.javabuild.command.SetVersion;
@@ -935,6 +940,77 @@ class MavenCommandHandlerTest {
   }
 
   @Nested
+  class HandleRemoveAnnotationProcessor {
+
+    @Test
+    void shouldRemoveCompilerAnnotationProcessorPath() {
+      Path pom = projectWithPom("src/test/resources/projects/init-maven/pom.xml");
+      MavenCommandHandler mavenCommandHandler = new MavenCommandHandler(Indentation.DEFAULT, pom);
+      mavenCommandHandler.handle(new AddJavaAnnotationProcessor(googleAutoServiceAnnotationProcessor()));
+      mavenCommandHandler.handle(
+        new AddJavaAnnotationProcessor(javaAnnotationProcessorDependency().groupId("org.hibernate.orm").artifactId("auto-service").build())
+      );
+      mavenCommandHandler.handle(new AddJavaAnnotationProcessor(hibernateAnnotationProcessor()));
+
+      mavenCommandHandler.handle(new RemoveJavaAnnotationProcessor(hibernateAnnotationProcessor().id()));
+
+      assertThat(contentNormalizingNewLines(pom))
+        .contains(
+          // language=XML
+          """
+                      <path>
+                        <groupId>com.google.auto.service</groupId>
+                        <artifactId>auto-service</artifactId>
+                        <version>${google-auto-service.version}</version>
+                      </path>
+          """
+        )
+        .doesNotContain(
+          // language=XML
+          """
+                      <path>
+                        <groupId>org.hibernate.orm</groupId>
+                        <artifactId>hibernate-processor</artifactId>
+                      </path>
+          """
+        );
+    }
+
+    @Test
+    void shouldRemoveCompilerAnnotationProcessorPathsIfTheresNoRemainingAnnotationProcessorPaths() {
+      Path pom = projectWithPom("src/test/resources/projects/init-maven/pom.xml");
+      MavenCommandHandler mavenCommandHandler = new MavenCommandHandler(Indentation.DEFAULT, pom);
+      mavenCommandHandler.handle(new AddJavaAnnotationProcessor(googleAutoServiceAnnotationProcessor()));
+
+      mavenCommandHandler.handle(new RemoveJavaAnnotationProcessor(googleAutoServiceAnnotationProcessor().id()));
+
+      assertThat(contentNormalizingNewLines(pom)).doesNotContain("<annotationProcessorPaths");
+    }
+
+    @Test
+    void shouldRemoveCompilerAnnotationProcessorPathWithVersionToPluginManagementPlugins() {
+      Path pom = projectWithPom("src/test/resources/projects/maven-with-plugin-management-compiler/pom.xml");
+
+      MavenCommandHandler mavenCommandHandler = new MavenCommandHandler(Indentation.DEFAULT, pom);
+      mavenCommandHandler.handle(new AddJavaAnnotationProcessor(googleAutoServiceAnnotationProcessor()));
+
+      mavenCommandHandler.handle(new RemoveJavaAnnotationProcessor(googleAutoServiceAnnotationProcessor().id()));
+
+      assertThat(contentNormalizingNewLines(pom)).doesNotContain(
+        """
+                    <annotationProcessorPaths>
+                      <path>
+                        <groupId>com.google.auto.service</groupId>
+                        <artifactId>auto-service</artifactId>
+                        <version>${google-auto-service.version}</version>
+                      </path>
+                    </annotationProcessorPaths>
+        """
+      );
+    }
+  }
+
+  @Nested
   class HandleAddDirectJavaDependency {
 
     @Test
@@ -1080,6 +1156,111 @@ class MavenCommandHandlerTest {
             </profile>
         """
       );
+    }
+  }
+
+  @Nested
+  class HandleAddAnnotationProcessor {
+
+    @Test
+    void shouldAddCompilerAnnotationProcessorPathWithoutVersionToPlugins() {
+      Path pom = projectWithPom("src/test/resources/projects/init-maven/pom.xml");
+
+      new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddJavaAnnotationProcessor(hibernateAnnotationProcessor()));
+
+      assertThat(contentNormalizingNewLines(pom)).contains(
+        // language=XML
+        """
+              <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                  <release>${java.version}</release>
+                  <annotationProcessorPaths>
+                    <path>
+                      <groupId>org.hibernate.orm</groupId>
+                      <artifactId>hibernate-processor</artifactId>
+                    </path>
+                  </annotationProcessorPaths>
+                </configuration>
+              </plugin>
+        """
+      );
+    }
+
+    @Test
+    void shouldAddCompilerAnnotationProcessorPathWithVersionToPlugins() {
+      Path pom = projectWithPom("src/test/resources/projects/init-maven/pom.xml");
+
+      new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddJavaAnnotationProcessor(googleAutoServiceAnnotationProcessor()));
+
+      assertThat(contentNormalizingNewLines(pom)).contains(
+        """
+              <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                  <release>${java.version}</release>
+                  <annotationProcessorPaths>
+                    <path>
+                      <groupId>com.google.auto.service</groupId>
+                      <artifactId>auto-service</artifactId>
+                      <version>${google-auto-service.version}</version>
+                    </path>
+                  </annotationProcessorPaths>
+                </configuration>
+              </plugin>
+        """
+      );
+    }
+
+    @Test
+    void shouldAddCompilerAnnotationProcessorPathWithVersionToPluginManagementPlugins() {
+      Path pom = projectWithPom("src/test/resources/projects/maven-with-plugin-management-compiler/pom.xml");
+
+      new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddJavaAnnotationProcessor(googleAutoServiceAnnotationProcessor()));
+
+      assertThat(contentNormalizingNewLines(pom)).contains(
+        """
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <configuration>
+                    <annotationProcessorPaths>
+                      <path>
+                        <groupId>com.google.auto.service</groupId>
+                        <artifactId>auto-service</artifactId>
+                        <version>${google-auto-service.version}</version>
+                      </path>
+                    </annotationProcessorPaths>
+                  </configuration>
+                  <version>${compiler-plugin.version}</version>
+                </plugin>
+        """
+      );
+    }
+
+    @Test
+    void shouldNotDuplicateAnnotationProcessorPath() {
+      Path pom = projectWithPom("src/test/resources/projects/init-maven/pom.xml");
+      MavenCommandHandler mavenCommandHandler = new MavenCommandHandler(Indentation.DEFAULT, pom);
+
+      mavenCommandHandler.handle(new AddJavaAnnotationProcessor(hibernateAnnotationProcessor()));
+      mavenCommandHandler.handle(new AddJavaAnnotationProcessor(hibernateAnnotationProcessor()));
+
+      assertThat(contentNormalizingNewLines(pom)).containsOnlyOnce("<artifactId>hibernate-processor</artifactId>");
+    }
+
+    @Test
+    void shouldFailIfCompilerPluginIsNotDeclared() {
+      Path pom = projectWithPom("src/main/resources/generator/buildtool/maven/pom.xml.mustache");
+      MavenCommandHandler mavenCommandHandler = new MavenCommandHandler(Indentation.DEFAULT, pom);
+
+      assertThatThrownBy(() -> mavenCommandHandler.handle(new AddJavaAnnotationProcessor(googleAutoServiceAnnotationProcessor())))
+        .isInstanceOf(GeneratorException.class)
+        .hasMessageContaining("maven-compiler-plugin should already be declared to add annotation processor dependencies");
     }
   }
 

--- a/src/test/java/com/seed4j/module/infrastructure/secondary/javadependency/maven/MavenProjectJavaDependenciesRepositoryTest.java
+++ b/src/test/java/com/seed4j/module/infrastructure/secondary/javadependency/maven/MavenProjectJavaDependenciesRepositoryTest.java
@@ -78,6 +78,26 @@ class MavenProjectJavaDependenciesRepositoryTest {
     assertThat(dependencies.get(DependencyId.of(new GroupId("org.springdoc"), new ArtifactId("springdoc-openapi-ui")))).isEmpty();
   }
 
+  @Test
+  void shouldGetAnnotationProcessingDependenciesFromMavenFile() {
+    DependencyId autoServiceDependencyId = DependencyId.builder().groupId("com.google.auto.service").artifactId("auto-service").build();
+
+    assertThat(mavenDependencies().annotationProcessor(autoServiceDependencyId)).hasValueSatisfying(autoService -> {
+      assertThat(autoService.version()).contains(new VersionSlug("auto-service"));
+      assertThat(autoService.classifier()).isEmpty();
+    });
+  }
+
+  @Test
+  void shouldGetAnnotationProcessingDependenciesFromDirectPluginsSection() {
+    DependencyId autoServiceDependencyId = DependencyId.builder().groupId("com.google.auto.service").artifactId("auto-service").build();
+
+    assertThat(mavenDirectPluginsDependencies().annotationProcessor(autoServiceDependencyId)).hasValueSatisfying(autoService -> {
+      assertThat(autoService.version()).contains(new VersionSlug("auto-service"));
+      assertThat(autoService.classifier()).isEmpty();
+    });
+  }
+
   private void assertJJWTDependency(JavaDependencies dependencies) {
     JavaDependency jjwt = dependencies
       .get(
@@ -106,5 +126,9 @@ class MavenProjectJavaDependenciesRepositoryTest {
 
   private ProjectJavaDependencies mavenDependencies() {
     return projectDependencies.get(new Seed4JProjectFolder("src/test/resources/projects/maven"));
+  }
+
+  private ProjectJavaDependencies mavenDirectPluginsDependencies() {
+    return projectDependencies.get(new Seed4JProjectFolder("src/test/resources/projects/maven-direct-plugins"));
   }
 }

--- a/src/test/resources/com/seed4j/module/infrastructure/secondary/FileSystemSeed4JModulesRepositoryTest.shouldApplyModuleToGradleProject.build.gradle.kts.approved.txt
+++ b/src/test/resources/com/seed4j/module/infrastructure/secondary/FileSystemSeed4JModulesRepositoryTest.shouldApplyModuleToGradleProject.build.gradle.kts.approved.txt
@@ -62,6 +62,8 @@ dependencies {
   }
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  annotationProcessor(libs.hibernate.processor)
+  // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies
   testImplementation(libs.commons.lang3)
   testImplementation(libs.reflections)

--- a/src/test/resources/com/seed4j/module/infrastructure/secondary/FileSystemSeed4JModulesRepositoryTest.shouldApplyModuleToGradleProject.build.gradle.kts.approved.txt
+++ b/src/test/resources/com/seed4j/module/infrastructure/secondary/FileSystemSeed4JModulesRepositoryTest.shouldApplyModuleToGradleProject.build.gradle.kts.approved.txt
@@ -62,6 +62,7 @@ dependencies {
   }
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  annotationProcessor(platform(libs.spring.boot.dependencies))
   annotationProcessor(libs.hibernate.processor)
   // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies

--- a/src/test/resources/com/seed4j/module/infrastructure/secondary/FileSystemSeed4JModulesRepositoryTest.shouldApplyModuleToGradleProject.libs.versions.toml.approved.txt
+++ b/src/test/resources/com/seed4j/module/infrastructure/secondary/FileSystemSeed4JModulesRepositoryTest.shouldApplyModuleToGradleProject.libs.versions.toml.approved.txt
@@ -61,6 +61,10 @@ bundles = {}
 		[libraries.cassandra-unit.version]
 			ref = "cassandraunit"
 
+	[libraries.hibernate-processor]
+		name = "hibernate-processor"
+		group = "org.hibernate.orm"
+
 	[libraries.gradle-git-properties]
 		name = "gradle-git-properties"
 		group = "com.gorylenko.gradle-git-properties"

--- a/src/test/resources/com/seed4j/module/infrastructure/secondary/FileSystemSeed4JModulesRepositoryTest.shouldApplyModuleToMavenProject.pom.xml.approved.txt
+++ b/src/test/resources/com/seed4j/module/infrastructure/secondary/FileSystemSeed4JModulesRepositoryTest.shouldApplyModuleToMavenProject.pom.xml.approved.txt
@@ -11,6 +11,7 @@
     <json-web-token.version>[version]</json-web-token.version>
     <logstash-logback-encoder.version>[version]</logstash-logback-encoder.version>
     <spring-boot.version>[version]</spring-boot.version>
+    <auto-service.version>[version]</auto-service.version>
     <commons-lang3.version>[version]</commons-lang3.version>
     <reflections.version>[version]</reflections.version>
     <maven-enforcer-plugin.version>[version]</maven-enforcer-plugin.version>
@@ -112,6 +113,21 @@
     </plugins>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${compiler-plugin.version}</version>
+          <configuration>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-processor</artifactId>
+                
+              </path>
+              
+            </annotationProcessorPaths>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/test/resources/projects/empty-gradle/build.gradle.kts
+++ b/src/test/resources/projects/empty-gradle/build.gradle.kts
@@ -32,6 +32,7 @@ val profiles = (project.findProperty("profiles") as String? ?: "")
 dependencies {
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies
   // seed4j-needle-gradle-test-dependencies
 }

--- a/src/test/resources/projects/gradle-with-local-profile-and-properties/buildSrc/src/main/kotlin/profile-local.gradle.kts
+++ b/src/test/resources/projects/gradle-with-local-profile-and-properties/buildSrc/src/main/kotlin/profile-local.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies
   // seed4j-needle-gradle-test-dependencies
 }

--- a/src/test/resources/projects/gradle-with-local-profile/build.gradle.kts
+++ b/src/test/resources/projects/gradle-with-local-profile/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies
   // seed4j-needle-gradle-test-dependencies
 }

--- a/src/test/resources/projects/gradle-with-local-profile/buildSrc/src/main/kotlin/profile-local.gradle.kts
+++ b/src/test/resources/projects/gradle-with-local-profile/buildSrc/src/main/kotlin/profile-local.gradle.kts
@@ -16,6 +16,7 @@ val libs = versionCatalogs.named("libs")
 dependencies {
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies
   // seed4j-needle-gradle-test-dependencies
 }

--- a/src/test/resources/projects/gradle-with-properties/build.gradle.kts
+++ b/src/test/resources/projects/gradle-with-properties/build.gradle.kts
@@ -31,6 +31,7 @@ val profiles = (project.findProperty("profiles") as String? ?: "")
 dependencies {
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies
   // seed4j-needle-gradle-test-dependencies
 }

--- a/src/test/resources/projects/init-gradle/build.gradle.kts
+++ b/src/test/resources/projects/init-gradle/build.gradle.kts
@@ -32,6 +32,7 @@ val profiles = (project.findProperty("profiles") as String? ?: "")
 dependencies {
   // seed4j-needle-gradle-implementation-dependencies
   // seed4j-needle-gradle-compile-dependencies
+  // seed4j-needle-gradle-annotation-processors
   // seed4j-needle-gradle-runtime-dependencies
   // seed4j-needle-gradle-test-dependencies
 }

--- a/src/test/resources/projects/maven-direct-plugins/pom.xml
+++ b/src/test/resources/projects/maven-direct-plugins/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>seed4j-test-maven-direct-plugins</artifactId>
+  <version>0.0.1</version>
+  <name>Test project</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <auto-service.version>1.1.0</auto-service.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.service</groupId>
+              <artifactId>auto-service</artifactId>
+              <version>${auto-service.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/projects/maven-with-plugin-management-compiler/pom.xml
+++ b/src/test/resources/projects/maven-with-plugin-management-compiler/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.seed4j.growth</groupId>
+  <artifactId>myapp</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>myapp</name>
+  <description>My App</description>
+  <packaging>jar</packaging>
+
+  <properties>
+    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${compiler-plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/test/resources/projects/maven/pom.xml
+++ b/src/test/resources/projects/maven/pom.xml
@@ -15,6 +15,7 @@
     <json-web-token.version>0.11.5</json-web-token.version>
     <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
     <spring-boot.version>2.7.1</spring-boot.version>
+    <auto-service.version>1.1.0</auto-service.version>
   </properties>
 
   <dependencyManagement>
@@ -59,6 +60,24 @@
     </plugins>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${compiler-plugin.version}</version>
+          <configuration>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>com.google.auto.service</groupId>
+                <artifactId>auto-service</artifactId>
+                <version>${auto-service.version}</version>
+              </path>
+              <path>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-processor</artifactId>
+              </path>
+            </annotationProcessorPaths>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -135,6 +135,7 @@ elif [[ $application == fullapp* ]]; then
     "infinitest-filters" \
     "pagination-domain" \
     "rest-pagination" \
+    "jpa-metamodel-generator" \
     "jpa-pagination" \
     "spring-boot-async" \
     "spring-boot-devtools" \


### PR DESCRIPTION
- support declaring annotation processors to java compiler. Fixes #13662
- add new module 'jpa-metamodel-generator'. Fixes #13663
- fix typo in JPA MySQL module
- Spring-Boot configuration processor should now be explicitly declared as annotation processor in order to work with java 25+