### PR TITLE
fix(tikui): run npm install after adding @prettier/plugin-pug dependency

### DIFF
--- a/src/main/java/com/seed4j/generator/client/tikui/application/TikuiApplicationService.java
+++ b/src/main/java/com/seed4j/generator/client/tikui/application/TikuiApplicationService.java
@@ -2,13 +2,18 @@ package com.seed4j.generator.client.tikui.application;
 
 import com.seed4j.generator.client.tikui.domain.TikuiModuleFactory;
 import com.seed4j.module.domain.Seed4JModule;
+import com.seed4j.module.domain.nodejs.NodeLazyPackagesInstaller;
 import com.seed4j.module.domain.properties.Seed4JModuleProperties;
 import org.springframework.stereotype.Service;
 
 @Service
 public class TikuiApplicationService {
 
-  private final TikuiModuleFactory tikui = new TikuiModuleFactory();
+  private final TikuiModuleFactory tikui;
+
+  public TikuiApplicationService(NodeLazyPackagesInstaller nodeLazyPackagesInstaller) {
+    this.tikui = new TikuiModuleFactory(nodeLazyPackagesInstaller);
+  }
 
   public Seed4JModule buildModule(Seed4JModuleProperties properties) {
     return tikui.buildModule(properties);

--- a/src/main/java/com/seed4j/generator/client/tikui/domain/TikuiModuleFactory.java
+++ b/src/main/java/com/seed4j/generator/client/tikui/domain/TikuiModuleFactory.java
@@ -17,6 +17,7 @@ import static com.seed4j.module.domain.nodejs.Seed4JNodePackagesVersionSource.CO
 import com.seed4j.module.domain.Seed4JModule;
 import com.seed4j.module.domain.file.Seed4JDestination;
 import com.seed4j.module.domain.file.Seed4JSource;
+import com.seed4j.module.domain.nodejs.NodeLazyPackagesInstaller;
 import com.seed4j.module.domain.properties.Seed4JModuleProperties;
 import com.seed4j.module.domain.replacement.RegexNeedleAfterReplacer;
 import com.seed4j.module.domain.replacement.ReplacementCondition;
@@ -49,6 +50,12 @@ public class TikuiModuleFactory {
   private static final String TEMPLATE_TOASTING = TEMPLATE + "/toasting";
   private static final String QUARK = "quark";
 
+  private final NodeLazyPackagesInstaller nodeLazyPackagesInstaller;
+
+  public TikuiModuleFactory(NodeLazyPackagesInstaller nodeLazyPackagesInstaller) {
+    this.nodeLazyPackagesInstaller = nodeLazyPackagesInstaller;
+  }
+
   public Seed4JModule buildModule(Seed4JModuleProperties properties) {
     // @formatter:off
     return moduleBuilder(properties)
@@ -65,6 +72,9 @@ public class TikuiModuleFactory {
         .addDevDependency(packageName("tikuidoc-tikui"), COMMON)
         .addScript(scriptKey("build:tikui"), scriptCommand("tikui-core build"))
         .addScript(scriptKey("dev:tikui"), scriptCommand("tikui-core serve"))
+        .and()
+      .postActions()
+        .add(context -> nodeLazyPackagesInstaller.runInstallIn(context.projectFolder(), properties.nodePackageManager()))
         .and()
       .files()
         .add(SOURCE.template("tikuiconfig.json"), to("tikuiconfig.json"))

--- a/src/test/java/com/seed4j/generator/client/tikui/domain/TikuiModuleFactoryTest.java
+++ b/src/test/java/com/seed4j/generator/client/tikui/domain/TikuiModuleFactoryTest.java
@@ -6,15 +6,25 @@ import static com.seed4j.module.infrastructure.secondary.Seed4JModulesAssertions
 import com.seed4j.TestFileUtils;
 import com.seed4j.UnitTest;
 import com.seed4j.module.domain.Seed4JModule;
+import com.seed4j.module.domain.nodejs.NodeLazyPackagesInstaller;
 import com.seed4j.module.domain.properties.Seed4JModuleProperties;
 import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
+@ExtendWith(MockitoExtension.class)
 class TikuiModuleFactoryTest {
 
-  private static final TikuiModuleFactory factory = new TikuiModuleFactory();
+  @InjectMocks
+  private TikuiModuleFactory factory;
+
+  @Mock
+  private NodeLazyPackagesInstaller nodeLazyPackagesInstaller;
 
   @Nested
   class Prettier {
@@ -139,7 +149,7 @@ class TikuiModuleFactoryTest {
     return Set.of("_" + name + ".scss", name + ".code.pug", name + ".md", name + ".mixin.pug", name + ".render.pug").toArray(String[]::new);
   }
 
-  private static Seed4JModuleAsserter assertThatTikuiModule(ModuleFile proxyFile, ModuleFile indexFile) {
+  private Seed4JModuleAsserter assertThatTikuiModule(ModuleFile proxyFile, ModuleFile indexFile) {
     Seed4JModuleProperties properties = propertiesBuilder(TestFileUtils.tmpDirForTest()).build();
 
     Seed4JModule module = factory.buildModule(properties);


### PR DESCRIPTION
TikuiModuleFactory added @prettier/plugin-pug to package.json and .prettierrc but had no postActions to install it before the git pre-commit hook ran. This caused prettier to fail with "Cannot find package '@prettier/plugin-pug'" when the hook tried to format staged .pug files, resulting in a 500 error from the apply-patch API endpoint.

Fix by injecting NodeLazyPackagesInstaller into TikuiModuleFactory and calling runInstallIn in postActions, matching the pattern used by PrettierModuleFactory and other framework modules.

Closes #11106