### PR TITLE
Improve pipeline speed

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -447,6 +447,12 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.java-build-tool }}-${{ matrix.app }}-${{ steps.cache_gradle_md5sum.outputs.md5sum }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.java-build-tool }}-
+      - name: 'Init: cache Playwright'
+        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright
       - name: 'Test: starting Sonar'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: /tmp/seed4j/${{ matrix.app }}/

--- a/src/main/docker/sonar/Dockerfile
+++ b/src/main/docker/sonar/Dockerfile
@@ -1,11 +1,10 @@
-FROM ubuntu:26.04
+FROM alpine:3.22.4
 RUN \
-  apt update && \
-  apt --no-install-recommends install -y curl jq && \
-  groupadd seed4j && \
-  useradd seed4j -s /bin/bash -m -g seed4j -G sudo && \
-  echo 'seed4j:seed4j'|chpasswd && \
-  apt clean
+  apk update && \
+  apk add --no-cache curl jq && \
+  addgroup -S seed4j && \
+  adduser -S -s /bin/ash -D -H -G seed4j seed4j && \
+  echo 'seed4j:seed4j'|chpasswd
 ENV \
   SEED4J_SONAR_URL=http://sonar:9000 \
   SEED4J_SONAR_PASSWORD=Seed4J-1339-Project \

--- a/src/main/docker/sonar/sonar_generate_token.sh
+++ b/src/main/docker/sonar/sonar_generate_token.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env ash
 
 until [[ "$(curl -s $SEED4J_SONAR_URL/api/system/status | jq -r .status)" = "UP" ]]; do
   sleep 5

--- a/src/main/resources/generator/ci/sonarqube/sonar/Dockerfile
+++ b/src/main/resources/generator/ci/sonarqube/sonar/Dockerfile
@@ -1,11 +1,10 @@
-FROM ubuntu:26.04
+FROM alpine:3.22.4
 RUN \
-  apt update && \
-  apt --no-install-recommends install -y curl jq && \
-  groupadd seed4j && \
-  useradd seed4j -s /bin/bash -m -g seed4j -G sudo && \
-  echo 'seed4j:seed4j'|chpasswd && \
-  apt clean
+  apk update && \
+  apk add --no-cache curl jq && \
+  addgroup -S seed4j && \
+  adduser -S -s /bin/ash -D -H -G seed4j seed4j && \
+  echo 'seed4j:seed4j'|chpasswd
 ENV \
   SEED4J_SONAR_URL=http://sonar:9000 \
   SEED4J_SONAR_PASSWORD=Seed4J-1339-Project \

--- a/src/main/resources/generator/ci/sonarqube/sonar/sonar_generate_token.sh
+++ b/src/main/resources/generator/ci/sonarqube/sonar/sonar_generate_token.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env ash
 
 until [[ "$(curl -s $SEED4J_SONAR_URL/api/system/status | jq -r .status)" = "UP" ]]; do
   sleep 5


### PR DESCRIPTION
- add cache for playwright browsers
- use alpine image for docker image retrieving the sonar token

Result : https://github.com/seed4j/seed4j/actions/runs/25864602660/usage?pr=14387

- Everything under 10 minutes
- Longest part on average is the sonar image download (https://github.com/seed4j/seed4j/pull/14388) 