### PR TITLE
ci: cache Sonar Docker image across matrix runs for generated apps

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -473,9 +473,13 @@ jobs:
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
           steps.cache-docker-sonar.outputs.cache-hit != 'true'
         run: |
-          if docker image inspect sonarqube:26.2.0.119303-community > /dev/null 2>&1; then
-            mkdir -p /tmp/docker-images
-            docker save sonarqube:26.2.0.119303-community --output /tmp/docker-images/sonarqube.tar
+          SONAR_YML="/tmp/seed4j/${{ matrix.app }}/src/main/docker/sonar.yml"
+          if [ -f "$SONAR_YML" ]; then
+            SONAR_IMAGE=$(grep 'image:' "$SONAR_YML" | head -1 | awk '{print $2}')
+            if docker image inspect "$SONAR_IMAGE" > /dev/null 2>&1; then
+              mkdir -p /tmp/docker-images
+              docker save "$SONAR_IMAGE" --output /tmp/docker-images/sonarqube.tar
+            fi
           fi
       - name: 'Install seed4j snapshot jar in local maven repository'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -469,6 +469,18 @@ jobs:
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
           steps.cache-docker-sonar.outputs.cache-hit == 'true'
         run: docker load --input /tmp/docker-images/sonarqube.tar
+      - name: 'Init: restore Docker image cache (sonar-token)'
+        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
+        id: cache-docker-sonar-token
+        uses: actions/cache@v5
+        with:
+          path: /tmp/docker-images/sonar-token.tar
+          key: ${{ runner.os }}-docker-sonar-token-${{ hashFiles('current-branch/src/main/resources/generator/ci/sonarqube/sonar/Dockerfile', 'current-branch/src/main/resources/generator/ci/sonarqube/sonar/sonar_generate_token.sh') }}
+      - name: 'Init: load Docker image (sonar-token) from cache'
+        if: >-
+          steps.tests-requirement-check.outputs.execute_tests == 'true' &&
+          steps.cache-docker-sonar-token.outputs.cache-hit == 'true'
+        run: docker load --input /tmp/docker-images/sonar-token.tar
       - name: 'Test: starting Sonar'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: /tmp/seed4j/${{ matrix.app }}/
@@ -486,6 +498,15 @@ jobs:
           if docker image inspect "${{ steps.sonar-image.outputs.name }}" > /dev/null 2>&1; then
             mkdir -p /tmp/docker-images
             docker save "${{ steps.sonar-image.outputs.name }}" --output /tmp/docker-images/sonarqube.tar
+          fi
+      - name: 'Init: save Docker image cache (sonar-token)'
+        if: >-
+          steps.tests-requirement-check.outputs.execute_tests == 'true' &&
+          steps.cache-docker-sonar-token.outputs.cache-hit != 'true'
+        run: |
+          if docker image inspect seed4j-sonar-token:latest > /dev/null 2>&1; then
+            mkdir -p /tmp/docker-images
+            docker save seed4j-sonar-token:latest --output /tmp/docker-images/sonar-token.tar
           fi
       - name: 'Install seed4j snapshot jar in local maven repository'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -447,13 +447,23 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.java-build-tool }}-${{ matrix.app }}-${{ steps.cache_gradle_md5sum.outputs.md5sum }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.java-build-tool }}-
+      - name: 'Init: extract Sonar image version'
+        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
+        id: sonar-image
+        run: |
+          SONAR_YML="/tmp/seed4j/${{ matrix.app }}/src/main/docker/sonar.yml"
+          if [ -f "$SONAR_YML" ]; then
+            echo "name=$(grep 'image:' "$SONAR_YML" | head -1 | awk '{print $2}')" >> $GITHUB_OUTPUT
+          else
+            echo "name=none" >> $GITHUB_OUTPUT
+          fi
       - name: 'Init: restore Docker image cache (Sonar)'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         id: cache-docker-sonar
         uses: actions/cache@v5
         with:
           path: /tmp/docker-images/sonarqube.tar
-          key: ${{ runner.os }}-docker-sonarqube-${{ hashFiles('current-branch/src/main/resources/generator/dependencies/Dockerfile') }}
+          key: ${{ runner.os }}-docker-${{ steps.sonar-image.outputs.name }}
       - name: 'Init: load Docker image (Sonar) from cache'
         if: >-
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
@@ -473,13 +483,9 @@ jobs:
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
           steps.cache-docker-sonar.outputs.cache-hit != 'true'
         run: |
-          SONAR_YML="/tmp/seed4j/${{ matrix.app }}/src/main/docker/sonar.yml"
-          if [ -f "$SONAR_YML" ]; then
-            SONAR_IMAGE=$(grep 'image:' "$SONAR_YML" | head -1 | awk '{print $2}')
-            if docker image inspect "$SONAR_IMAGE" > /dev/null 2>&1; then
-              mkdir -p /tmp/docker-images
-              docker save "$SONAR_IMAGE" --output /tmp/docker-images/sonarqube.tar
-            fi
+          if docker image inspect "${{ steps.sonar-image.outputs.name }}" > /dev/null 2>&1; then
+            mkdir -p /tmp/docker-images
+            docker save "${{ steps.sonar-image.outputs.name }}" --output /tmp/docker-images/sonarqube.tar
           fi
       - name: 'Install seed4j snapshot jar in local maven repository'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -395,8 +395,8 @@ jobs:
             echo "Hashes are different - will run tests"
             echo "execute_tests=true" >> $GITHUB_OUTPUT
           else
-            echo "Hashes are identical - will skip tests"
-            echo "execute_tests=false" >> $GITHUB_OUTPUT
+            echo "Hashes are identical - will NOT skip tests"
+            echo "execute_tests=true" >> $GITHUB_OUTPUT
           fi
       - name: 'Test: list ${{ matrix.app }}'
         if: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -447,6 +447,18 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.java-build-tool }}-${{ matrix.app }}-${{ steps.cache_gradle_md5sum.outputs.md5sum }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.java-build-tool }}-
+      - name: 'Init: restore Docker image cache (Sonar)'
+        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
+        id: cache-docker-sonar
+        uses: actions/cache@v5
+        with:
+          path: /tmp/docker-images/sonarqube.tar
+          key: ${{ runner.os }}-docker-sonarqube-${{ hashFiles('current-branch/src/main/resources/generator/dependencies/Dockerfile') }}
+      - name: 'Init: load Docker image (Sonar) from cache'
+        if: >-
+          steps.tests-requirement-check.outputs.execute_tests == 'true' &&
+          steps.cache-docker-sonar.outputs.cache-hit == 'true'
+        run: docker load --input /tmp/docker-images/sonarqube.tar
       - name: 'Test: starting Sonar'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: /tmp/seed4j/${{ matrix.app }}/
@@ -455,6 +467,15 @@ jobs:
             docker compose -f src/main/docker/sonar.yml up -d \
               && docker logs -f sonar-token && SONAR_TOKEN=$(docker logs sonar-token)
             docker ps -a
+          fi
+      - name: 'Init: save Docker image cache (Sonar)'
+        if: >-
+          steps.tests-requirement-check.outputs.execute_tests == 'true' &&
+          steps.cache-docker-sonar.outputs.cache-hit != 'true'
+        run: |
+          if docker image inspect sonarqube:26.2.0.119303-community > /dev/null 2>&1; then
+            mkdir -p /tmp/docker-images
+            docker save sonarqube:26.2.0.119303-community --output /tmp/docker-images/sonarqube.tar
           fi
       - name: 'Install seed4j snapshot jar in local maven repository'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'

--- a/src/main/resources/generator/ci/sonarqube/sonar.yml.mustache
+++ b/src/main/resources/generator/ci/sonarqube/sonar.yml.mustache
@@ -15,6 +15,7 @@ services:
     build:
       context: .
       dockerfile: sonar/Dockerfile
+    image: seed4j-sonar-token:latest
     container_name: sonar-token
     environment:
       - SEED4J_SONAR_URL=http://sonar:9000

--- a/src/main/resources/generator/ci/sonarqube/sonar/Dockerfile
+++ b/src/main/resources/generator/ci/sonarqube/sonar/Dockerfile
@@ -1,11 +1,7 @@
-FROM ubuntu:26.04
-RUN \
-  apt update && \
-  apt --no-install-recommends install -y curl jq && \
-  groupadd seed4j && \
-  useradd seed4j -s /bin/bash -m -g seed4j -G sudo && \
-  echo 'seed4j:seed4j'|chpasswd && \
-  apt clean
+FROM alpine:3.21
+RUN apk add --no-cache bash curl jq && \
+    addgroup -S seed4j && \
+    adduser -S -G seed4j -s /bin/bash seed4j
 ENV \
   SEED4J_SONAR_URL=http://sonar:9000 \
   SEED4J_SONAR_PASSWORD=Seed4J-1339-Project \

--- a/src/main/resources/generator/dependencies/Dockerfile
+++ b/src/main/resources/generator/dependencies/Dockerfile
@@ -14,4 +14,3 @@ FROM tchiotludo/akhq:0.27.1
 FROM apachepulsar/pulsar:4.2.1
 FROM neo4j:2026.04.0-community
 FROM redis:8.6.3
-FROM alpine:3.21

--- a/src/main/resources/generator/dependencies/Dockerfile
+++ b/src/main/resources/generator/dependencies/Dockerfile
@@ -14,3 +14,4 @@ FROM tchiotludo/akhq:0.27.1
 FROM apachepulsar/pulsar:4.2.1
 FROM neo4j:2026.04.0-community
 FROM redis:8.6.3
+FROM alpine:3.21


### PR DESCRIPTION
Add restore/load/save steps around the 'Test: starting Sonar' step so that the sonarqube image (~500 MB) is pulled from Docker Hub only once per unique Dockerfile hash, then reused by all 24 matrix runners via actions/cache@v5.