### PR TITLE
Fix workflow and cache issues

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,7 +8,8 @@ inputs:
   node-version:
     description: 'Node version to use'
     required: true
-    default: 'lts/*'
+    default: '24.15.0'
+    # Pinned to 24.15.0 until https://github.com/cypress-io/cypress/pull/33887 is released. Then 'lts/*' can be used again
   node-package-manager:
     description: 'Package manager to use for installing node dependencies'
     required: true

--- a/src/test/webapp/component/integration/Landscape.spec.ts
+++ b/src/test/webapp/component/integration/Landscape.spec.ts
@@ -5,6 +5,7 @@ describe('Landscape', () => {
   beforeEach(() => cy.intercept({ path: '/api/project-folders' }, { body: '/tmp/seed4j/1234' }));
 
   it('should change theme after toggle switch theme button', () => {
+    const result = interceptForever({ path: '/api/modules-landscape' }, { fixture: 'landscape.json' });
     cy.visit('/landscape', {
       // see https://www.cypress.io/blog/2019/12/13/test-your-web-app-in-dark-mode/
       onBeforeLoad(win) {
@@ -12,18 +13,25 @@ describe('Landscape', () => {
       },
     });
 
-    const themeSwitchButton = dataSelector('theme-switch-button');
+    cy.get(dataSelector('landscape-loader'))
+      .should('be.visible')
+      .then(() => {
+        result.send();
+        cy.get(dataSelector('landscape-loader')).should('not.exist');
 
-    cy.get(themeSwitchButton).should('exist').should('not.be.visible').should('not.be.checked');
-    cy.get('[aria-label="dark-theme"]').should('exist');
+        const themeSwitchButton = dataSelector('theme-switch-button');
 
-    cy.get(themeSwitchButton).click({ force: true });
-    cy.get(themeSwitchButton).should('be.checked');
-    cy.get('[aria-label="light-theme"]').should('exist');
+        cy.get(themeSwitchButton).should('exist').should('not.be.visible').should('not.be.checked');
+        cy.get('[aria-label="dark-theme"]').should('exist');
 
-    cy.get(themeSwitchButton).click({ force: true });
-    cy.get(themeSwitchButton).should('not.be.checked');
-    cy.get('[aria-label="dark-theme"]').should('exist');
+        cy.get(themeSwitchButton).click({ force: true });
+        cy.get(themeSwitchButton).should('be.checked');
+        cy.get('[aria-label="light-theme"]').should('exist');
+
+        cy.get(themeSwitchButton).click({ force: true });
+        cy.get(themeSwitchButton).should('not.be.checked');
+        cy.get('[aria-label="dark-theme"]').should('exist');
+      });
   });
 
   it('should display landscape as default page', () => {

--- a/src/test/webapp/component/integration/Patch.spec.ts
+++ b/src/test/webapp/component/integration/Patch.spec.ts
@@ -23,24 +23,34 @@ describe('Patch', () => {
   });
 
   it('should change theme after toggle switch theme button', () => {
+    const result = interceptForever({ path: '/api/modules' }, { fixture: 'modules.json' });
+
     cy.visit('/patches', {
       onBeforeLoad(win) {
         cy.stub(win, 'matchMedia').withArgs('(prefers-color-scheme: dark)').returns({ matches: true });
       },
     });
 
-    const themeSwitchButton = dataSelector('theme-switch-button');
+    cy.get(dataSelector('modules-loader'))
+      .should('be.visible')
+      .then(() => {
+        result.send();
+        cy.get(dataSelector('modules-loader')).should('not.exist');
+        cy.get(dataSelector('modules-list')).should('be.visible');
 
-    cy.get(themeSwitchButton).should('exist').should('not.be.visible').should('not.be.checked');
-    cy.get('[aria-label="dark-theme"]').should('exist');
+        const themeSwitchButton = dataSelector('theme-switch-button');
 
-    cy.get(themeSwitchButton).click({ force: true });
-    cy.get(themeSwitchButton).should('be.checked');
-    cy.get('[aria-label="light-theme"]').should('exist');
+        cy.get(themeSwitchButton).should('not.be.checked');
+        cy.get('[aria-label="dark-theme"]').should('exist');
 
-    cy.get(themeSwitchButton).click({ force: true });
-    cy.get(themeSwitchButton).should('not.be.checked');
-    cy.get('[aria-label="dark-theme"]').should('exist');
+        cy.get(themeSwitchButton).click({ force: true });
+        cy.get(themeSwitchButton).should('be.checked');
+        cy.get('[aria-label="light-theme"]').should('exist');
+
+        cy.get(themeSwitchButton).click({ force: true });
+        cy.get(themeSwitchButton).should('not.be.checked');
+        cy.get('[aria-label="dark-theme"]').should('exist');
+      });
   });
 
   it('should apply module without properties', () => {


### PR DESCRIPTION
# Windows issue
The tests-windows job has some issues : 
<img width="1065" height="563" alt="image" src="https://github.com/user-attachments/assets/e3f2bd43-4f5c-4701-961f-0172beb93c53" />

One correlation factor is the use of previous cache. All jobs I checked had the error when the cache was missing.
The problem is that I cannot find anything related to the cypress cache in previous commit

After some research, I found https://github.com/cypress-io/cypress/pull/33887 and rolling back to node 24.15.0 does fix the job https://github.com/seed4j/seed4j/actions/runs/26359102398/job/77591255298?pr=14420

Node LTS release made May 21 : https://nodejs.org/fr/blog/release/v24.16.0

# Linux issue
Tests are flaky