### PR TITLE
fix: configure forwarded headers strategy

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -76,6 +76,7 @@ seed4j:
 
 server:
   port: 1339
+  forward-headers-strategy: framework
 
 spring:
   threads:


### PR DESCRIPTION
Configure Spring Boot to use the framework forwarded headers strategy.

This allows forwarded headers to be handled correctly when Seed4J is deployed behind a proxy using HTTPS.

Closes #12245

Tests:
- Maven test suite passes